### PR TITLE
Feature/801 add license scan to ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults_working_directory: &defaults_working_directory
 
 defaults_docker_node: &defaults_docker_node
   docker:
-    - image: mhart/alpine-node:10.15.1
+    - image: node:10.15.3-alpine
 
 defaults_docker_helm_kube: &defaults_docker_helm_kube
   docker:
@@ -17,6 +17,7 @@ defaults_Dependencies: &defaults_Dependencies |
     apk --no-cache add ca-certificates
     apk --no-cache add curl
     apk --no-cache add openssh-client
+    apk --no-cache add bash
     apk add --no-cache -t build-dependencies make gcc g++ python libtool autoconf automake
 
 defaults_awsCliDependencies: &defaults_awsCliDependencies |
@@ -28,6 +29,12 @@ defaults_awsCliDependencies: &defaults_awsCliDependencies |
             mailcap
     pip install --upgrade awscli==1.14.5 s3cmd==2.0.1 python-magic
     apk -v --purge del py-pip
+
+defaults_license_scanner: &defaults_license_scanner
+  name: Install and set up license-scanner
+  command: |
+    git clone https://github.com/mojaloop/license-scanner /tmp/license-scanner
+    cd /tmp/license-scanner && make build default-files set-up
 
 defaults_build_docker_login: &defaults_build_docker_login
   name: Login to Docker Hub
@@ -302,6 +309,45 @@ jobs:
 #       - store_test_results:
 #           path: ./test/results
 
+  vulnerability-check:
+    <<: *defaults_working_directory
+    <<: *defaults_docker_node
+    steps:
+      - run:
+          name: Install general dependencies
+          command: *defaults_Dependencies
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run:
+          name: Create dir for test results
+          command: mkdir -p ./audit/results
+      - run:
+          name: Check for new npm vulnerabilities
+          command: npm run audit:check -- --json > ./audit/results/auditResults.json 
+      - store_artifacts:
+          path: ./audit/results
+          prefix: audit
+
+  audit-licenses:
+    <<: *defaults_working_directory
+    <<: *defaults_docker_node
+    steps:
+      - run:
+          name: Install general dependencies
+          command: *defaults_Dependencies
+      - run:
+          <<: *defaults_license_scanner
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run:
+          name: Run the license-scanner
+          command: cd /tmp/license-scanner && pathToRepo=$CIRCLE_WORKING_DIRECTORY make run
+      - store_artifacts:
+          path: /tmp/license-scanner/results
+          prefix: licenses
+
   build-snapshot:
     machine: true
     <<: *defaults_working_directory
@@ -332,6 +378,14 @@ jobs:
           <<: *defaults_build_docker_login
       - run:
           <<: *defaults_build_docker_build
+      - run:
+          <<: *defaults_license_scanner
+      - run:
+          name: Run the license-scanner
+          command: cd /tmp/license-scanner && mode=docker dockerImage=$DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG make run
+      - store_artifacts:
+          path: /tmp/license-scanner/results
+          prefix: licenses
       - run:
           <<: *defaults_build_docker_publish
       - run:
@@ -473,6 +527,28 @@ workflows:
       #         ignore:
       #           - /feature*/
       #           - /bugfix*/
+      - vulnerability-check:
+          context: org-global
+          requires:
+            - setup
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore:
+                - /feature*/
+                - /bugfix*/
+      - audit-licenses:
+          context: org-global
+          requires:
+            - setup
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore:
+                - /feature*/
+                - /bugfix*/
       - build-snapshot:
           context: org-global
           requires:
@@ -482,6 +558,8 @@ workflows:
             - test-integration
             # - test-functional
             # - test-spec
+            - vulnerability-check
+            - audit-licenses
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*\-snapshot/
@@ -507,6 +585,8 @@ workflows:
             - test-integration
             # - test-functional
             # - test-spec
+            - vulnerability-check
+            - audit-licenses
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/

--- a/README.md
+++ b/README.md
@@ -238,3 +238,20 @@ Running the tests:
 
 
 Tests include code coverage via istanbul. See the test/ folder for testing scripts.
+
+
+## Auditing Dependencies
+
+We use `npm-audit-resolver` along with `npm audit` to check dependencies for vulnerabilities, and keep track of resolved dependencies with an `audit-resolv.json` file.
+
+To start a new resolution process, run:
+```bash
+npm run audit:resolve
+```
+
+You can then check to see if the CI will pass based on the current dependencies with:
+```bash
+npm run audit:check
+```
+
+And commit the changed `audit-resolv.json` to ensure that CircleCI will build correctly.

--- a/audit-resolv.json
+++ b/audit-resolv.json
@@ -19,5 +19,11 @@
   },
   "1065|@mojaloop/central-services-database>lodash": {
     "ignore": 1
+  },
+  "786|@mojaloop/central-services-database>knex>liftoff>findup-sync>micromatch>braces": {
+    "ignore": 1
+  },
+  "782|@mojaloop/central-services-database>lodash": {
+    "ignore": 1
   }
 }

--- a/audit-resolv.json
+++ b/audit-resolv.json
@@ -1,0 +1,107 @@
+{
+  "782|istanbul>istanbul-api>istanbul-lib-instrument>babel-generator>babel-types>lodash": {
+    "fix": 1
+  },
+  "782|istanbul>istanbul-api>istanbul-lib-instrument>babel-generator>lodash": {
+    "fix": 1
+  },
+  "782|istanbul>istanbul-api>istanbul-lib-instrument>babel-template>babel-traverse>babel-types>lodash": {
+    "fix": 1
+  },
+  "782|istanbul>istanbul-api>istanbul-lib-instrument>babel-template>babel-traverse>lodash": {
+    "fix": 1
+  },
+  "782|istanbul>istanbul-api>istanbul-lib-instrument>babel-template>babel-types>lodash": {
+    "fix": 1
+  },
+  "782|istanbul>istanbul-api>istanbul-lib-instrument>babel-template>lodash": {
+    "fix": 1
+  },
+  "782|istanbul>istanbul-api>istanbul-lib-instrument>babel-traverse>babel-types>lodash": {
+    "fix": 1
+  },
+  "782|istanbul>istanbul-api>istanbul-lib-instrument>babel-traverse>lodash": {
+    "fix": 1
+  },
+  "782|istanbul>istanbul-api>istanbul-lib-instrument>babel-types>lodash": {
+    "fix": 1
+  },
+  "782|tap-xunit>xmlbuilder>lodash": {
+    "fix": 1
+  },
+  "1065|@mojaloop/central-services-error-handling>@mojaloop/central-services-shared>winston>async>lodash": {
+    "fix": 1
+  },
+  "1065|@mojaloop/central-services-shared>winston>async>lodash": {
+    "fix": 1
+  },
+  "1065|istanbul>istanbul-api>async>lodash": {
+    "fix": 1
+  },
+  "1065|istanbul>istanbul-api>istanbul-reports>handlebars>async>lodash": {
+    "fix": 1
+  },
+  "1065|sinon>@sinonjs/formatio>@sinonjs/samsam>lodash": {
+    "fix": 1
+  },
+  "1065|sinon>@sinonjs/samsam>lodash": {
+    "fix": 1
+  },
+  "1065|sinon>nise>@sinonjs/formatio>@sinonjs/samsam>lodash": {
+    "fix": 1
+  },
+  "1065|istanbul>istanbul-api>istanbul-lib-instrument>babel-generator>babel-types>lodash": {
+    "fix": 1
+  },
+  "1065|istanbul>istanbul-api>istanbul-lib-instrument>babel-generator>lodash": {
+    "fix": 1
+  },
+  "1065|istanbul>istanbul-api>istanbul-lib-instrument>babel-template>babel-traverse>babel-types>lodash": {
+    "fix": 1
+  },
+  "1065|istanbul>istanbul-api>istanbul-lib-instrument>babel-template>babel-traverse>lodash": {
+    "fix": 1
+  },
+  "1065|istanbul>istanbul-api>istanbul-lib-instrument>babel-template>babel-types>lodash": {
+    "fix": 1
+  },
+  "1065|istanbul>istanbul-api>istanbul-lib-instrument>babel-template>lodash": {
+    "fix": 1
+  },
+  "1065|istanbul>istanbul-api>istanbul-lib-instrument>babel-traverse>babel-types>lodash": {
+    "fix": 1
+  },
+  "1065|istanbul>istanbul-api>istanbul-lib-instrument>babel-traverse>lodash": {
+    "fix": 1
+  },
+  "1065|istanbul>istanbul-api>istanbul-lib-instrument>babel-types>lodash": {
+    "fix": 1
+  },
+  "1065|tap-xunit>xmlbuilder>lodash": {
+    "fix": 1
+  },
+  "788|istanbul>istanbul-api>js-yaml": {
+    "fix": 1
+  },
+  "788|istanbul>js-yaml": {
+    "fix": 1
+  },
+  "788|tap-xunit>tap-parser>js-yaml": {
+    "fix": 1
+  },
+  "813|istanbul>istanbul-api>js-yaml": {
+    "fix": 1
+  },
+  "813|istanbul>js-yaml": {
+    "fix": 1
+  },
+  "813|tap-xunit>tap-parser>js-yaml": {
+    "fix": 1
+  },
+  "755|istanbul>istanbul-api>istanbul-reports>handlebars": {
+    "fix": 1
+  },
+  "1065|@mojaloop/central-services-database>lodash": {
+    "ignore": 1
+  }
+}

--- a/audit-resolv.json
+++ b/audit-resolv.json
@@ -1,105 +1,21 @@
 {
-  "782|istanbul>istanbul-api>istanbul-lib-instrument>babel-generator>babel-types>lodash": {
-    "fix": 1
-  },
-  "782|istanbul>istanbul-api>istanbul-lib-instrument>babel-generator>lodash": {
-    "fix": 1
-  },
-  "782|istanbul>istanbul-api>istanbul-lib-instrument>babel-template>babel-traverse>babel-types>lodash": {
-    "fix": 1
-  },
-  "782|istanbul>istanbul-api>istanbul-lib-instrument>babel-template>babel-traverse>lodash": {
-    "fix": 1
-  },
-  "782|istanbul>istanbul-api>istanbul-lib-instrument>babel-template>babel-types>lodash": {
-    "fix": 1
-  },
-  "782|istanbul>istanbul-api>istanbul-lib-instrument>babel-template>lodash": {
-    "fix": 1
-  },
-  "782|istanbul>istanbul-api>istanbul-lib-instrument>babel-traverse>babel-types>lodash": {
-    "fix": 1
-  },
-  "782|istanbul>istanbul-api>istanbul-lib-instrument>babel-traverse>lodash": {
-    "fix": 1
-  },
-  "782|istanbul>istanbul-api>istanbul-lib-instrument>babel-types>lodash": {
-    "fix": 1
-  },
-  "782|tap-xunit>xmlbuilder>lodash": {
-    "fix": 1
-  },
   "1065|@mojaloop/central-services-error-handling>@mojaloop/central-services-shared>winston>async>lodash": {
-    "fix": 1
+    "ignore": 1
   },
   "1065|@mojaloop/central-services-shared>winston>async>lodash": {
-    "fix": 1
+    "ignore": 1
   },
   "1065|istanbul>istanbul-api>async>lodash": {
-    "fix": 1
-  },
-  "1065|istanbul>istanbul-api>istanbul-reports>handlebars>async>lodash": {
-    "fix": 1
+    "ignore": 1
   },
   "1065|sinon>@sinonjs/formatio>@sinonjs/samsam>lodash": {
-    "fix": 1
+    "ignore": 1
   },
   "1065|sinon>@sinonjs/samsam>lodash": {
-    "fix": 1
+    "ignore": 1
   },
   "1065|sinon>nise>@sinonjs/formatio>@sinonjs/samsam>lodash": {
-    "fix": 1
-  },
-  "1065|istanbul>istanbul-api>istanbul-lib-instrument>babel-generator>babel-types>lodash": {
-    "fix": 1
-  },
-  "1065|istanbul>istanbul-api>istanbul-lib-instrument>babel-generator>lodash": {
-    "fix": 1
-  },
-  "1065|istanbul>istanbul-api>istanbul-lib-instrument>babel-template>babel-traverse>babel-types>lodash": {
-    "fix": 1
-  },
-  "1065|istanbul>istanbul-api>istanbul-lib-instrument>babel-template>babel-traverse>lodash": {
-    "fix": 1
-  },
-  "1065|istanbul>istanbul-api>istanbul-lib-instrument>babel-template>babel-types>lodash": {
-    "fix": 1
-  },
-  "1065|istanbul>istanbul-api>istanbul-lib-instrument>babel-template>lodash": {
-    "fix": 1
-  },
-  "1065|istanbul>istanbul-api>istanbul-lib-instrument>babel-traverse>babel-types>lodash": {
-    "fix": 1
-  },
-  "1065|istanbul>istanbul-api>istanbul-lib-instrument>babel-traverse>lodash": {
-    "fix": 1
-  },
-  "1065|istanbul>istanbul-api>istanbul-lib-instrument>babel-types>lodash": {
-    "fix": 1
-  },
-  "1065|tap-xunit>xmlbuilder>lodash": {
-    "fix": 1
-  },
-  "788|istanbul>istanbul-api>js-yaml": {
-    "fix": 1
-  },
-  "788|istanbul>js-yaml": {
-    "fix": 1
-  },
-  "788|tap-xunit>tap-parser>js-yaml": {
-    "fix": 1
-  },
-  "813|istanbul>istanbul-api>js-yaml": {
-    "fix": 1
-  },
-  "813|istanbul>js-yaml": {
-    "fix": 1
-  },
-  "813|tap-xunit>tap-parser>js-yaml": {
-    "fix": 1
-  },
-  "755|istanbul>istanbul-api>istanbul-reports>handlebars": {
-    "fix": 1
+    "ignore": 1
   },
   "1065|@mojaloop/central-services-database>lodash": {
     "ignore": 1

--- a/examples/client.js
+++ b/examples/client.js
@@ -31,17 +31,17 @@ class ForensicLogger extends EventEmitter {
   }
 
   write (msg) {
-    let message = Buffer.isBuffer(msg) ? msg : Buffer.from(msg)
-    let length = message.length
+    const message = Buffer.isBuffer(msg) ? msg : Buffer.from(msg)
+    const length = message.length
 
-    let buffer = Buffer.alloc(this._prefixSize + length)
+    const buffer = Buffer.alloc(this._prefixSize + length)
     buffer.writeUInt32BE(length, 0)
     message.copy(buffer, this._prefixSize)
     this._client.write(buffer)
   }
 }
 
-let logger = new ForensicLogger()
+const logger = new ForensicLogger()
 
 logger.on('open', () => {
   logger.write(JSON.stringify(LargeData))

--- a/package-lock.json
+++ b/package-lock.json
@@ -2078,12 +2078,11 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
-      "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
-      "dev": true,
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
       "requires": {
-        "async": "^2.5.0",
+        "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
@@ -2092,8 +2091,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -3006,9 +3004,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
-      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -3247,9 +3245,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash.includes": {
@@ -3550,6 +3548,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "neo-async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -3887,7 +3890,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -3896,14 +3898,12 @@
         "minimist": {
           "version": "0.0.10",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
         },
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
         }
       }
     },
@@ -5696,28 +5696,19 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
-      "dev": true,
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
+      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
       "optional": true,
       "requires": {
-        "commander": "~2.17.1",
+        "commander": "~2.20.0",
         "source-map": "~0.6.1"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.17.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-          "dev": true,
-          "optional": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
           "optional": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,22 +32,6 @@
         }
       }
     },
-    "@babel/polyfill": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
-      "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.2"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.13.3",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
-        }
-      }
-    },
     "@modusbox/mojaloop-sdk-standard-components": {
       "version": "0.0.36",
       "resolved": "https://registry.npmjs.org/@modusbox/mojaloop-sdk-standard-components/-/mojaloop-sdk-standard-components-0.0.36.tgz",
@@ -62,35 +46,47 @@
       }
     },
     "@mojaloop/central-services-database": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-database/-/central-services-database-5.2.1.tgz",
-      "integrity": "sha512-hvqNZ63ylgYTKUBHzOeaQoRwGafMqToIq1/HZXPJ0WtqAsVg59yJs9DG3fvg66v4P+6Ub16wwrW17HDHjpgPqQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-database/-/central-services-database-0.4.0.tgz",
+      "integrity": "sha512-oCO8Wgmr1pJ9/IWU/8S6MXsij8TxQCBSh+Lzst3YGaivhy3HNAcNFVwQNYEVHt6Sstp5J0J5uLndojHC0OWLOw==",
       "requires": {
-        "bluebird": "3.5.3",
-        "knex": "0.16.3",
-        "lodash": "4.17.11",
-        "mysql": "2.16.0",
-        "url": "0.11.0"
+        "bluebird": "3.5.0",
+        "knex": "0.14.2",
+        "lodash": "4.17.5",
+        "pg": "7.4.1"
       },
       "dependencies": {
         "bluebird": {
-          "version": "3.5.3",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-          "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
         },
         "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
         },
-        "url": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-          "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+        "pg": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/pg/-/pg-7.4.1.tgz",
+          "integrity": "sha512-Pi5qYuXro5PAD9xXx8h7bFtmHgAQEG6/SCNyi7gS3rvb/ZQYDmxKchfB0zYtiSJNWq9iXTsYsHjrM+21eBcN1A==",
+          "optional": true,
           "requires": {
-            "punycode": "1.3.2",
-            "querystring": "0.2.0"
+            "buffer-writer": "1.0.1",
+            "js-string-escape": "1.0.1",
+            "packet-reader": "0.3.1",
+            "pg-connection-string": "0.1.3",
+            "pg-pool": "~2.0.3",
+            "pg-types": "~1.12.1",
+            "pgpass": "1.x",
+            "semver": "4.3.2"
           }
+        },
+        "pg-connection-string": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
+          "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=",
+          "optional": true
         }
       }
     },
@@ -177,11 +173,6 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
-    "@types/bluebird": {
-      "version": "3.5.27",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.27.tgz",
-      "integrity": "sha512-6BmYWSBea18+tSjjSC3QIyV93ZKAeNWGM7R6aYt1ryTZXrlHF+QLV0G2yV0viEGVyRkyQsWfMoJ0k/YghBX5sQ=="
-    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -250,19 +241,17 @@
       }
     },
     "arr-diff": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "requires": {
+        "arr-flatten": "^1.0.1"
+      }
     },
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
-    },
-    "arr-union": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-each": {
       "version": "1.0.1",
@@ -309,9 +298,9 @@
       "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w=="
     },
     "array-unique": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
     },
     "asn1": {
       "version": "0.2.4",
@@ -325,11 +314,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
-    "assign-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "astral-regex": {
       "version": "1.0.0",
@@ -361,11 +345,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "atob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "aws-sdk": {
       "version": "2.496.0",
@@ -461,7 +440,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -532,56 +510,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "base": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-      "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "requires": {
-            "is-descriptor": "^1.0.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        }
-      }
-    },
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
@@ -607,11 +535,6 @@
           "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         }
       }
-    },
-    "bignumber.js": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
-      "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
     },
     "bitsyntax": {
       "version": "0.1.0",
@@ -649,30 +572,13 @@
       }
     },
     "braces": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "buffer": {
@@ -702,21 +608,11 @@
       "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
       "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg=="
     },
-    "cache-base": {
+    "buffer-writer": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-      "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
-      }
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
+      "integrity": "sha1-Iqk2kB4wKa/NdUfrRIfOtpejvwg=",
+      "optional": true
     },
     "callsites": {
       "version": "3.1.0",
@@ -739,6 +635,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -750,27 +647,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
-    },
-    "class-utils": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-      "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        }
-      }
     },
     "cli-cursor": {
       "version": "2.1.0",
@@ -786,15 +662,6 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
-    },
-    "collection-visit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-      "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
-      }
     },
     "color": {
       "version": "3.0.0",
@@ -859,11 +726,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
       "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
-    "component-emitter": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -887,11 +749,6 @@
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
-    },
-    "copy-descriptor": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
       "version": "2.6.5",
@@ -936,7 +793,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -946,11 +802,6 @@
       "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
-    },
-    "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "deep-equal": {
       "version": "0.1.2",
@@ -1001,43 +852,6 @@
         }
       }
     },
-    "define-property": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-      "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
-      },
-      "dependencies": {
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        }
-      }
-    },
     "defined": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
@@ -1072,9 +886,12 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "detect-file": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
-      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
+      "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
+      "requires": {
+        "fs-exists-sync": "^0.1.0"
+      }
     },
     "detect-indent": {
       "version": "4.0.0",
@@ -1604,76 +1421,33 @@
       "dev": true
     },
     "expand-brackets": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "requires": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
+        "is-posix-bracket": "^0.1.0"
+      }
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "requires": {
+        "fill-range": "^2.1.0"
       }
     },
     "expand-tilde": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+      "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "os-homedir": "^1.0.1"
       }
     },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "extend-shallow": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-      "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
-      },
-      "dependencies": {
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
-        }
-      }
     },
     "extensible-error": {
       "version": "1.0.2",
@@ -1692,61 +1466,17 @@
       }
     },
     "extglob": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "requires": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "is-extglob": "^1.0.0"
       },
       "dependencies": {
-        "define-property": {
+        "is-extglob": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "requires": {
-            "is-descriptor": "^1.0.0"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
         }
       }
     },
@@ -1836,6 +1566,11 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+    },
     "fileset": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
@@ -1857,24 +1592,15 @@
       }
     },
     "fill-range": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "find-root": {
@@ -1893,14 +1619,29 @@
       }
     },
     "findup-sync": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
-      "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
+      "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
       "requires": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^3.1.0",
-        "micromatch": "^3.0.4",
-        "resolve-dir": "^1.0.1"
+        "detect-file": "^0.1.0",
+        "is-glob": "^2.0.1",
+        "micromatch": "^2.3.7",
+        "resolve-dir": "^0.1.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
       }
     },
     "fined": {
@@ -1913,12 +1654,22 @@
         "object.defaults": "^1.1.0",
         "object.pick": "^1.2.0",
         "parse-filepath": "^1.0.1"
+      },
+      "dependencies": {
+        "expand-tilde": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+          "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+          "requires": {
+            "homedir-polyfill": "^1.0.1"
+          }
+        }
       }
     },
     "flagged-respawn": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
-      "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
+      "integrity": "sha1-/xke3c1wiKZ1smEP/8l2vpuAdLU="
     },
     "flat-cache": {
       "version": "2.0.1",
@@ -1952,9 +1703,9 @@
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
     "for-own": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-      "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "requires": {
         "for-in": "^1.0.1"
       }
@@ -1974,13 +1725,10 @@
         "mime-types": "^2.1.12"
       }
     },
-    "fragment-cache": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-      "requires": {
-        "map-cache": "^0.2.2"
-      }
+    "fs-exists-sync": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -2000,16 +1748,16 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "generic-pool": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.7.1.tgz",
+      "integrity": "sha512-ug6DAZoNgWm6q5KhPFA+hzXfBLFQu5sTXxPpv44DmE0A2g+CiHoq9LTVdkXpZMkYVMoGw83F6W+WT0h0MFMK/w=="
+    },
     "get-stdin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
       "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
       "dev": true
-    },
-    "get-value": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
     "getpass": {
       "version": "0.1.7",
@@ -2033,6 +1781,38 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "requires": {
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "requires": {
+            "is-glob": "^2.0.0"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
+      }
+    },
     "glob-parent": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -2044,25 +1824,23 @@
       }
     },
     "global-modules": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+      "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
       "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
+        "global-prefix": "^0.1.4",
+        "is-windows": "^0.2.0"
       }
     },
     "global-prefix": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
-      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+      "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
+        "homedir-polyfill": "^1.0.0",
         "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "is-windows": "^0.2.0",
+        "which": "^1.2.12"
       }
     },
     "globals": {
@@ -2081,6 +1859,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
       "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -2091,7 +1870,8 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -2403,42 +2183,14 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
-    },
-    "has-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-      "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
-      }
-    },
-    "has-values": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-      "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
     },
     "homedir-polyfill": {
       "version": "1.0.3",
@@ -2615,23 +2367,12 @@
       "requires": {
         "is-relative": "^1.0.0",
         "is-windows": "^1.0.1"
-      }
-    },
-    "is-accessor-descriptor": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-      "requires": {
-        "kind-of": "^3.0.2"
       },
       "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
+        "is-windows": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
         }
       }
     },
@@ -2651,45 +2392,23 @@
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
     },
-    "is-data-descriptor": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-      "requires": {
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
-    "is-descriptor": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        }
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -2700,7 +2419,8 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -2721,26 +2441,17 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+      "dev": true,
       "requires": {
         "is-extglob": "^2.1.0"
       }
     },
     "is-number": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "requires": {
         "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
       }
     },
     "is-object": {
@@ -2761,7 +2472,24 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
         "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
       }
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
     },
     "is-promise": {
       "version": "2.1.0",
@@ -2820,9 +2548,9 @@
       "dev": true
     },
     "is-windows": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+      "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
     },
     "isarray": {
       "version": "1.0.0",
@@ -2850,9 +2578,12 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "requires": {
+        "isarray": "1.0.0"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -2997,6 +2728,12 @@
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
       "dev": true
     },
+    "js-string-escape": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
+      "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
+      "optional": true
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -3133,51 +2870,60 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
     },
     "knex": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-0.16.3.tgz",
-      "integrity": "sha512-jGTOBW8b7exaBPfCKJSlv5q320IvWw9hEdtnURtbb0k3HusfZrR4UYiEewem8Nl7VqJILoCj99SjCK3W54UNPg==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-0.14.2.tgz",
+      "integrity": "sha1-87P+HqBxGvhCdwEAdoryG/y8uuo=",
       "requires": {
-        "@babel/polyfill": "^7.0.0",
-        "@types/bluebird": "^3.5.25",
-        "bluebird": "^3.5.3",
-        "chalk": "2.4.1",
-        "commander": "^2.19.0",
-        "debug": "4.1.0",
-        "inherits": "~2.0.3",
-        "interpret": "^1.1.0",
-        "liftoff": "2.5.0",
-        "lodash": "^4.17.11",
+        "babel-runtime": "^6.23.0",
+        "bluebird": "^3.4.6",
+        "chalk": "2.3.0",
+        "commander": "^2.2.0",
+        "debug": "3.1.0",
+        "generic-pool": "^3.1.7",
+        "inherits": "~2.0.1",
+        "interpret": "^1.0.4",
+        "liftoff": "2.3.0",
+        "lodash": "^4.6.0",
         "minimist": "1.2.0",
-        "mkdirp": "^0.5.1",
+        "mkdirp": "^0.5.0",
         "pg-connection-string": "2.0.0",
-        "tarn": "^1.1.4",
+        "readable-stream": "2.3.3",
+        "safe-buffer": "^5.0.1",
         "tildify": "1.2.0",
-        "uuid": "^3.3.2",
-        "v8flags": "^3.1.1"
+        "uuid": "^3.0.0",
+        "v8flags": "^3.0.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "requires": {
-            "ms": "^2.1.1"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
         },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "requires": {
+            "has-flag": "^2.0.0"
+          }
         }
       }
     },
@@ -3200,16 +2946,17 @@
       }
     },
     "liftoff": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
-      "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
+      "integrity": "sha1-qY8v9nGD2Lp8+soQVIvX/wVQs4U=",
       "requires": {
         "extend": "^3.0.0",
-        "findup-sync": "^2.0.0",
+        "findup-sync": "^0.4.2",
         "fined": "^1.0.1",
-        "flagged-respawn": "^1.0.0",
-        "is-plain-object": "^2.0.4",
-        "object.map": "^1.0.0",
+        "flagged-respawn": "^0.3.2",
+        "lodash.isplainobject": "^4.0.4",
+        "lodash.isstring": "^4.0.1",
+        "lodash.mapvalues": "^4.4.0",
         "rechoir": "^0.6.2",
         "resolve": "^1.1.7"
       }
@@ -3247,8 +2994,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -3279,6 +3025,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.mapvalues": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
     },
     "lodash.once": {
       "version": "4.1.1",
@@ -3334,26 +3085,15 @@
         "yallist": "^2.1.2"
       }
     },
-    "make-iterator": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
-      "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
-      "requires": {
-        "kind-of": "^6.0.2"
-      }
-    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
-    "map-visit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-      "requires": {
-        "object-visit": "^1.0.0"
-      }
+    "math-random": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
     },
     "memorystream": {
       "version": "0.3.1",
@@ -3377,23 +3117,38 @@
       }
     },
     "micromatch": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
       }
     },
     "mime-db": {
@@ -3428,25 +3183,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-    },
-    "mixin-deep": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
-      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
-      "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
-      },
-      "dependencies": {
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
-        }
-      }
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -3485,64 +3221,6 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
-    "mysql": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.16.0.tgz",
-      "integrity": "sha512-dPbN2LHonQp7D5ja5DJXNbCLe/HRdu+f3v61aguzNRQIrmZLOeRoymBYyeThrR6ug+FqzDL95Gc9maqZUJS+Gw==",
-      "requires": {
-        "bignumber.js": "4.1.0",
-        "readable-stream": "2.3.6",
-        "safe-buffer": "5.1.2",
-        "sqlstring": "2.3.1"
-      },
-      "dependencies": {
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
-    "nanomatch": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
-      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
-      "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      }
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3552,7 +3230,8 @@
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
@@ -3605,6 +3284,14 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "requires": {
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "npm-audit-resolver": {
@@ -3726,34 +3413,6 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
-    "object-copy": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-      "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
     "object-inspect": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
@@ -3765,14 +3424,6 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
       "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
       "dev": true
-    },
-    "object-visit": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-      "requires": {
-        "isobject": "^3.0.0"
-      }
     },
     "object.assign": {
       "version": "4.1.0",
@@ -3803,6 +3454,21 @@
         "array-slice": "^1.0.0",
         "for-own": "^1.0.0",
         "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "for-own": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+          "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+          "requires": {
+            "for-in": "^1.0.1"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
       }
     },
     "object.entries": {
@@ -3829,13 +3495,13 @@
         "has": "^1.0.1"
       }
     },
-    "object.map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
-      "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "requires": {
-        "for-own": "^1.0.0",
-        "make-iterator": "^1.0.0"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "object.pick": {
@@ -3844,6 +3510,13 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
         "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
       }
     },
     "object.values": {
@@ -3890,6 +3563,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -3898,12 +3572,14 @@
         "minimist": {
           "version": "0.0.10",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
         },
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
         }
       }
     },
@@ -3987,6 +3663,32 @@
         "path-root": "^0.1.1"
       }
     },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "requires": {
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
+      }
+    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -4001,11 +3703,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
-    },
-    "pascalcase": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
     "path-dirname": {
       "version": "1.0.2",
@@ -4145,6 +3842,18 @@
       "integrity": "sha512-hod2zYQxM8Gt482q+qONGTYcg/qVcV32VHVPtktbBJs0us3Dj7xibISw0BAAXVMCzt8A/jhfJvpZaxUlqtqs0g==",
       "optional": true
     },
+    "pg-types": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
+      "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
+      "optional": true,
+      "requires": {
+        "postgres-array": "~1.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.0",
+        "postgres-interval": "^1.1.0"
+      }
+    },
     "pgpass": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
@@ -4266,10 +3975,11 @@
         "find-up": "^2.1.0"
       }
     },
-    "posix-character-classes": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+    "postgres-array": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.3.tgz",
+      "integrity": "sha512-5wClXrAP0+78mcsNX3/ithQ5exKvCyK5lr5NEEEeGwwM6NJdQgzIJBVxLvRW+huFpX92F2QnZ5CcokH0VhK2qQ==",
+      "optional": true
     },
     "postgres-bytea": {
       "version": "1.0.0",
@@ -4331,11 +4041,15 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+    },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "progress": {
       "version": "2.0.3",
@@ -4390,7 +4104,8 @@
     "punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+      "dev": true
     },
     "qs": {
       "version": "6.5.2",
@@ -4400,7 +4115,30 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
+    },
+    "randomatic": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+      "requires": {
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        }
+      }
     },
     "rc": {
       "version": "1.2.8",
@@ -4508,7 +4246,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -4530,16 +4267,14 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
-    "regex-not": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regexpp": {
@@ -4547,6 +4282,11 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "repeat-element": {
       "version": "1.1.3",
@@ -4628,12 +4368,12 @@
       }
     },
     "resolve-dir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
-      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+      "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
       "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
+        "expand-tilde": "^1.2.2",
+        "global-modules": "^0.2.3"
       }
     },
     "resolve-from": {
@@ -4641,11 +4381,6 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
-    },
-    "resolve-url": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -4665,11 +4400,6 @@
       "requires": {
         "through": "~2.3.4"
       }
-    },
-    "ret": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "rimraf": {
       "version": "2.6.3",
@@ -4709,14 +4439,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
-    "safe-regex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-      "requires": {
-        "ret": "~0.1.10"
-      }
-    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -4732,27 +4454,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
       "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
-    },
-    "set-value": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
-      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
-      }
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -4838,132 +4539,11 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
-    "snapdragon": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-      "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
-      }
-    },
-    "snapdragon-node": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-      "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "requires": {
-            "is-descriptor": "^1.0.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        }
-      }
-    },
-    "snapdragon-util": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-      "requires": {
-        "kind-of": "^3.2.0"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-    },
-    "source-map-resolve": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
-      "requires": {
-        "atob": "^2.1.1",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
-      }
-    },
-    "source-map-url": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
     },
     "spawn-shell": {
       "version": "2.1.0",
@@ -5027,14 +4607,6 @@
         "through": "2"
       }
     },
-    "split-string": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-      "requires": {
-        "extend-shallow": "^3.0.0"
-      }
-    },
     "sprintf": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.5.tgz",
@@ -5046,11 +4618,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
-    },
-    "sqlstring": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
-      "integrity": "sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A="
     },
     "sshpk": {
       "version": "1.16.1",
@@ -5107,25 +4674,6 @@
         "get-stdin": "^7.0.0",
         "minimist": "^1.1.0",
         "pkg-conf": "^3.1.0"
-      }
-    },
-    "static-extend": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-      "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        }
       }
     },
     "stealthy-require": {
@@ -5186,7 +4734,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -5218,6 +4765,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -5490,11 +5038,6 @@
         }
       }
     },
-    "tarn": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/tarn/-/tarn-1.1.5.tgz",
-      "integrity": "sha512-PMtJ3HCLAZeedWjJPgGnCvcphbCOMbtZpjKgLq3qM5Qq9aQud+XHrL0WlrlgnTyS8U+jrjGbEXprFcQrxPy52g=="
-    },
     "text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -5579,44 +5122,6 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
-    "to-object-path": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-      "requires": {
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
-    "to-regex": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-      "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
-      }
-    },
-    "to-regex-range": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-      "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
-      }
-    },
     "tough-cookie": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -5699,6 +5204,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
       "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "dev": true,
       "optional": true,
       "requires": {
         "commander": "~2.20.0",
@@ -5709,6 +5215,7 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
           "optional": true
         }
       }
@@ -5718,58 +5225,11 @@
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
     },
-    "union-value": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
-      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
-      "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^2.0.1"
-      }
-    },
     "uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
-    },
-    "unset-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-      "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
-      },
-      "dependencies": {
-        "has-value": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-          "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-              "requires": {
-                "isarray": "1.0.0"
-              }
-            }
-          }
-        },
-        "has-values": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-        }
-      }
     },
     "uri-js": {
       "version": "4.2.2",
@@ -5786,11 +5246,6 @@
         }
       }
     },
-    "urix": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
-    },
     "url": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
@@ -5800,11 +5255,6 @@
         "punycode": "1.3.2",
         "querystring": "0.2.0"
       }
-    },
-    "use": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,63 +4,119 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@mojaloop/central-services-database": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-database/-/central-services-database-0.4.0.tgz",
-      "integrity": "sha512-oCO8Wgmr1pJ9/IWU/8S6MXsij8TxQCBSh+Lzst3YGaivhy3HNAcNFVwQNYEVHt6Sstp5J0J5uLndojHC0OWLOw==",
+    "@babel/code-frame": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+      "dev": true,
       "requires": {
-        "bluebird": "3.5.0",
-        "knex": "0.14.2",
-        "lodash": "4.17.5",
-        "pg": "7.4.1"
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/polyfill": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
+      "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
+    "@modusbox/mojaloop-sdk-standard-components": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@modusbox/mojaloop-sdk-standard-components/-/mojaloop-sdk-standard-components-0.0.36.tgz",
+      "integrity": "sha512-wtRm+BOvImnkSaq2UkAWWj3SWaSR2c6l8ibrNWNfZXJaGmcaWb+T+caue/XYGTtQyOjL1+q5Qe4P8ppfc6ZRBA==",
+      "requires": {
+        "base64url": "^3.0.1",
+        "ilp-packet": "2.2.0",
+        "jsonwebtoken": "^8.5.1",
+        "jws": "^3.2.2",
+        "request": "^2.34",
+        "request-promise-native": "^1.0.7"
+      }
+    },
+    "@mojaloop/central-services-database": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-database/-/central-services-database-5.2.1.tgz",
+      "integrity": "sha512-hvqNZ63ylgYTKUBHzOeaQoRwGafMqToIq1/HZXPJ0WtqAsVg59yJs9DG3fvg66v4P+6Ub16wwrW17HDHjpgPqQ==",
+      "requires": {
+        "bluebird": "3.5.3",
+        "knex": "0.16.3",
+        "lodash": "4.17.11",
+        "mysql": "2.16.0",
+        "url": "0.11.0"
       },
       "dependencies": {
         "bluebird": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+          "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
         },
-        "pg": {
-          "version": "7.4.1",
-          "resolved": "https://registry.npmjs.org/pg/-/pg-7.4.1.tgz",
-          "integrity": "sha512-Pi5qYuXro5PAD9xXx8h7bFtmHgAQEG6/SCNyi7gS3rvb/ZQYDmxKchfB0zYtiSJNWq9iXTsYsHjrM+21eBcN1A==",
-          "optional": true,
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "url": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+          "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
           "requires": {
-            "buffer-writer": "1.0.1",
-            "js-string-escape": "1.0.1",
-            "packet-reader": "0.3.1",
-            "pg-connection-string": "0.1.3",
-            "pg-pool": "~2.0.3",
-            "pg-types": "~1.12.1",
-            "pgpass": "1.x",
-            "semver": "4.3.2"
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
           }
-        },
-        "pg-connection-string": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
-          "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=",
-          "optional": true
         }
       }
     },
     "@mojaloop/central-services-error-handling": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-5.2.0.tgz",
-      "integrity": "sha512-aVl5kBQld7gAruGgiI2KeQZ+T9LIEpRx/lsrAjUkCCTRGd1ZfglJt+bEZpuNCD1KWRCXc0MHkk9hPR+nQFBKzA==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-7.1.2.tgz",
+      "integrity": "sha512-8bNKzNvZDG0ZFFgBPrWPXuUGTCbgBhtP1gjCatM8Vik3Wd5sK+8Zac1JLE1mK8x85gy7U8I4cIT74XEV7D5t9A==",
       "requires": {
-        "@mojaloop/central-services-shared": "5.2.0"
+        "@modusbox/mojaloop-sdk-standard-components": "0.0.36",
+        "@mojaloop/central-services-shared": "6.4.1"
+      }
+    },
+    "@mojaloop/central-services-shared": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-6.4.1.tgz",
+      "integrity": "sha512-ihtRxZiMghJgqXdstVi/qr0VepOfr2uA1VYfnPNB16TZoojWtG0xt538XG/3TfYJfxVOaShc+WlJBVoxUs774w==",
+      "requires": {
+        "async": "3.1.0",
+        "debug": "4.1.1",
+        "winston": "3.2.1"
       },
       "dependencies": {
-        "@mojaloop/central-services-shared": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-5.2.0.tgz",
-          "integrity": "sha512-wcHlPdJKziJMqjDIbYp8WLXT5ZI/0ITdrxl2QHDK03geZ6UWJ0B6EnRe1LPKWM2M/bBzzybB9vHU8UI+/QwXgw==",
-          "requires": {
-            "async": "2.6.2",
-            "debug": "4.1.1",
-            "winston": "3.2.1"
-          }
+        "async": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.1.0.tgz",
+          "integrity": "sha512-4vx/aaY6j/j3Lw3fbCHNWP0pPaTCew3F6F3hYyl/tHs/ndmV1q7NW9T5yuJ2XAGwdQrP+6Wu20x06U4APo/iQQ=="
         },
         "debug": {
           "version": "4.1.1",
@@ -71,42 +127,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        }
-      }
-    },
-    "@mojaloop/central-services-shared": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-0.4.0.tgz",
-      "integrity": "sha512-bqPVrgxgxdKH5G+oLnGEXf5JiCUWvJj1InIxhhbF7jsu9+7h9HBK2+zBwThzXFLEcq/SouZ+fKgpLrTAQEr7fA==",
-      "requires": {
-        "winston": "^2.4.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
-        },
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-        },
-        "winston": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
-          "integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
-          "requires": {
-            "async": "~1.0.0",
-            "colors": "1.0.x",
-            "cycle": "1.0.x",
-            "eyes": "0.1.x",
-            "isstream": "0.1.x",
-            "stack-trace": "0.0.x"
-          }
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -154,6 +177,11 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@types/bluebird": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.27.tgz",
+      "integrity": "sha512-6BmYWSBea18+tSjjSC3QIyV93ZKAeNWGM7R6aYt1ryTZXrlHF+QLV0G2yV0viEGVyRkyQsWfMoJ0k/YghBX5sQ=="
+    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -161,9 +189,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
+      "integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw==",
       "dev": true
     },
     "acorn-jsx": {
@@ -176,19 +204,12 @@
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
       "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
-    },
-    "ajv-keywords": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
-      "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
-      "dev": true
     },
     "ansi-escapes": {
       "version": "3.2.0",
@@ -229,17 +250,19 @@
       }
     },
     "arr-diff": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "requires": {
-        "arr-flatten": "^1.0.1"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
     },
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-each": {
       "version": "1.0.1",
@@ -286,9 +309,33 @@
       "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w=="
     },
     "array-unique": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
     },
     "async": {
       "version": "2.6.2",
@@ -310,10 +357,20 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+    },
     "aws-sdk": {
-      "version": "2.401.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.401.0.tgz",
-      "integrity": "sha512-mOI4gzKoP/g8Q0ToAaqTh7TijGG9PvGVVUkKmurXqBKy7GTPmy4JizfVkTrM+iBg7RAsx5H2lBxBFpdEFBa5fg==",
+      "version": "2.496.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.496.0.tgz",
+      "integrity": "sha512-6xZ//phdvp7/dUZjOdDsorl+xehhkAgxOMber9vUlMO9ckBOeufIvED7oKF0NvSlfG8laHK4JprXKQvhXqVLqA==",
       "dev": true,
       "requires": {
         "buffer": "4.9.1",
@@ -326,6 +383,16 @@
         "uuid": "3.3.2",
         "xml2js": "0.4.19"
       }
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -394,6 +461,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -464,11 +532,86 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
       "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
       "dev": true
+    },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+        }
+      }
+    },
+    "bignumber.js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
+      "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
     },
     "bitsyntax": {
       "version": "0.1.0",
@@ -491,9 +634,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -506,13 +649,30 @@
       }
     },
     "braces": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "buffer": {
@@ -526,6 +686,11 @@
         "isarray": "^1.0.0"
       }
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -537,25 +702,26 @@
       "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
       "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg=="
     },
-    "buffer-writer": {
+    "cache-base": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
-      "integrity": "sha1-Iqk2kB4wKa/NdUfrRIfOtpejvwg=",
-      "optional": true
-    },
-    "caller-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "requires": {
-        "callsites": "^0.2.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "callsites": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
     "camelcase": {
@@ -564,27 +730,47 @@
       "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
       "dev": true
     },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
     "chalk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "requires": {
-        "ansi-styles": "^3.1.0",
+        "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
-        "supports-color": "^4.0.0"
+        "supports-color": "^5.3.0"
       }
     },
     "chardet": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "circular-json": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-      "dev": true
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
     },
     "cli-cursor": {
       "version": "2.1.0",
@@ -600,6 +786,15 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
     },
     "color": {
       "version": "3.0.0",
@@ -643,18 +838,31 @@
       "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
     },
     "colorspace": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.1.tgz",
-      "integrity": "sha512-pI3btWyiuz7Ken0BWh9Elzsmv2bM9AhA7psXib4anUXy/orfZ/E0MbQwhSOG/9L8hLlalqrU0UhOuqxW1YjmVw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
       "requires": {
         "color": "3.0.x",
         "text-hex": "1.0.x"
       }
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -679,6 +887,11 @@
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
       "version": "2.6.5",
@@ -711,15 +924,19 @@
         }
       }
     },
-    "cycle": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -729,6 +946,11 @@
       "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "deep-equal": {
       "version": "0.1.2",
@@ -779,6 +1001,43 @@
         }
       }
     },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
     "defined": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
@@ -786,34 +1045,36 @@
       "dev": true
     },
     "deglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.1.tgz",
-      "integrity": "sha512-2kjwuGGonL7gWE1XU4Fv79+vVzpoQCl0V+boMwWtOQJV2AGDabCwez++nB1Nli/8BabAfZQ/UuHPlp6AymKdWw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/deglob/-/deglob-3.1.0.tgz",
+      "integrity": "sha512-al10l5QAYaM/PeuXkAr1Y9AQz0LCtWsnJG23pIgh44hDxHFOj36l6qvhfjnIWBYwZOqM1fXUFV9tkjL7JPdGvw==",
       "dev": true,
       "requires": {
         "find-root": "^1.0.0",
         "glob": "^7.0.5",
-        "ignore": "^3.0.9",
+        "ignore": "^5.0.0",
         "pkg-config": "^1.1.0",
         "run-parallel": "^1.1.2",
         "uniq": "^1.0.1"
       },
       "dependencies": {
         "ignore": {
-          "version": "3.3.10",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
+          "integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
           "dev": true
         }
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
     "detect-file": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
-      "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
-      "requires": {
-        "fs-exists-sync": "^0.1.0"
-      }
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
     },
     "detect-indent": {
       "version": "4.0.0",
@@ -841,9 +1102,9 @@
       "dev": true
     },
     "doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
@@ -853,6 +1114,29 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
     },
     "enabled": {
@@ -924,48 +1208,46 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.4.0.tgz",
-      "integrity": "sha512-UIpL91XGex3qtL6qwyCQJar2j3osKxK9e3ano3OcGEIRM4oWIpCkDg9x95AXEC2wMs7PnxzOkPZ2gq+tsMS9yg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.0.1.tgz",
+      "integrity": "sha512-DyQRaMmORQ+JsWShYsSg4OPTjY56u1nCjAmICrE8vLWqyLKxhFXOthwMj1SA8xwfrv0CofLNVnqbfyhwCkaO0w==",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.0",
-        "babel-code-frame": "^6.26.0",
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
         "chalk": "^2.1.0",
         "cross-spawn": "^6.0.5",
-        "debug": "^3.1.0",
-        "doctrine": "^2.1.0",
-        "eslint-scope": "^4.0.0",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^4.0.3",
         "eslint-utils": "^1.3.1",
         "eslint-visitor-keys": "^1.0.0",
-        "espree": "^4.0.0",
+        "espree": "^6.0.0",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
+        "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
+        "glob-parent": "^3.1.0",
         "globals": "^11.7.0",
-        "ignore": "^4.0.2",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^5.2.0",
-        "is-resolvable": "^1.1.0",
-        "js-yaml": "^3.11.0",
+        "inquirer": "^6.2.2",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.11",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
         "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
-        "pluralize": "^7.0.0",
         "progress": "^2.0.0",
-        "regexpp": "^2.0.0",
-        "require-uncached": "^1.0.3",
-        "semver": "^5.5.0",
+        "regexpp": "^2.0.1",
+        "semver": "^5.5.1",
         "strip-ansi": "^4.0.0",
         "strip-json-comments": "^2.0.1",
-        "table": "^4.0.3",
+        "table": "^5.2.3",
         "text-table": "^0.2.0"
       },
       "dependencies": {
@@ -975,16 +1257,56 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "globals": {
-          "version": "11.11.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
-          "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "js-yaml": {
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "semver": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true
         },
         "strip-ansi": {
@@ -999,15 +1321,15 @@
       }
     },
     "eslint-config-standard": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz",
-      "integrity": "sha512-COUz8FnXhqFitYj4DTqHzidjIL/t4mumGZto5c7DrBpvWoie+Sn3P4sLEzUGeYhRElWuFEf8K1S1EfvD1vixCQ==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-13.0.1.tgz",
+      "integrity": "sha512-zLKp4QOgq6JFgRm1dDCVv1Iu0P5uZ4v5Wa4DTOkg2RFMxdCX/9Qf7lz9ezRj2dBRa955cWQF/O/LWEiYWAHbTw==",
       "dev": true
     },
     "eslint-config-standard-jsx": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-6.0.2.tgz",
-      "integrity": "sha512-D+YWAoXw+2GIdbMBRAzWwr1ZtvnSf4n4yL0gKGg7ShUOGXkSOLerI17K4F6LdQMJPNMoWYqepzQD/fKY+tXNSg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-7.0.0.tgz",
+      "integrity": "sha512-OiKOF3MFVmWOCVfsi8GHlVorOEiBsPzAnUhM3c6HML94O2krbdQ/eMABySHgHHOIBYRls9sR9I3lo6O0vXhVEg==",
       "dev": true
     },
     "eslint-import-resolver-node": {
@@ -1032,9 +1354,9 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz",
-      "integrity": "sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
+      "integrity": "sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==",
       "dev": true,
       "requires": {
         "debug": "^2.6.8",
@@ -1063,21 +1385,22 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
-      "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
+      "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
       "dev": true,
       "requires": {
+        "array-includes": "^3.0.3",
         "contains-path": "^0.1.0",
-        "debug": "^2.6.8",
+        "debug": "^2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.1",
-        "eslint-module-utils": "^2.2.0",
-        "has": "^1.0.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.3",
+        "eslint-import-resolver-node": "^0.3.2",
+        "eslint-module-utils": "^2.4.0",
+        "has": "^1.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.0",
         "read-pkg-up": "^2.0.0",
-        "resolve": "^1.6.0"
+        "resolve": "^1.11.0"
       },
       "dependencies": {
         "debug": {
@@ -1098,48 +1421,96 @@
             "esutils": "^2.0.2",
             "isarray": "^1.0.0"
           }
+        },
+        "resolve": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+          "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
         }
       }
     },
     "eslint-plugin-node": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-7.0.1.tgz",
-      "integrity": "sha512-lfVw3TEqThwq0j2Ba/Ckn2ABdwmL5dkOgAux1rvOk6CO7A6yGyPI2+zIxN6FyNkp1X1X/BSvKOceD6mBWSj4Yw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-9.1.0.tgz",
+      "integrity": "sha512-ZwQYGm6EoV2cfLpE1wxJWsfnKUIXfM/KM09/TlorkukgCAwmkgajEJnPCmyzoFPQQkmvo5DrW/nyKutNIw36Mw==",
       "dev": true,
       "requires": {
-        "eslint-plugin-es": "^1.3.1",
+        "eslint-plugin-es": "^1.4.0",
         "eslint-utils": "^1.3.1",
-        "ignore": "^4.0.2",
+        "ignore": "^5.1.1",
         "minimatch": "^3.0.4",
-        "resolve": "^1.8.1",
-        "semver": "^5.5.0"
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
       },
       "dependencies": {
+        "ignore": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
+          "integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+          "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
         "semver": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
           "dev": true
         }
       }
     },
     "eslint-plugin-promise": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz",
-      "integrity": "sha512-Si16O0+Hqz1gDHsys6RtFRrW7cCTB6P7p3OJmKp3Y3dxpQE2qwOA7d3xnV+0mBmrPoi0RBnxlCKvqu70te6wjg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
+      "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
       "dev": true
     },
     "eslint-plugin-react": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz",
-      "integrity": "sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.2.tgz",
+      "integrity": "sha512-jZdnKe3ip7FQOdjxks9XPN0pjUKZYq48OggNMd16Sk+8VXx6JOvXmlElxROCgp7tiUsTsze3jd78s/9AFJP2mA==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
         "doctrine": "^2.1.0",
         "has": "^1.0.3",
-        "jsx-ast-utils": "^2.0.1",
-        "prop-types": "^15.6.2"
+        "jsx-ast-utils": "^2.1.0",
+        "object.entries": "^1.1.0",
+        "object.fromentries": "^2.0.0",
+        "object.values": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "resolve": "^1.10.1"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "resolve": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+          "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
       }
     },
     "eslint-plugin-standard": {
@@ -1149,9 +1520,9 @@
       "dev": true
     },
     "eslint-scope": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.2.tgz",
-      "integrity": "sha512-5q1+B/ogmHl8+paxtOKx38Z8LtWkVGuNt3+GQNErqwLl6ViNp/gdJGMCjZNxZ8j/VYjDNZ2Fo+eQc1TAVPIzbg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -1159,10 +1530,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
+      "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -1171,12 +1545,12 @@
       "dev": true
     },
     "espree": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
-      "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.0.0.tgz",
+      "integrity": "sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==",
       "dev": true,
       "requires": {
-        "acorn": "^6.0.2",
+        "acorn": "^6.0.7",
         "acorn-jsx": "^5.0.0",
         "eslint-visitor-keys": "^1.0.0"
       }
@@ -1230,27 +1604,51 @@
       "dev": true
     },
     "expand-brackets": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "requires": {
-        "is-posix-bracket": "^0.1.0"
-      }
-    },
-    "expand-range": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "requires": {
-        "fill-range": "^2.1.0"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "expand-tilde": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-      "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "requires": {
-        "os-homedir": "^1.0.1"
+        "homedir-polyfill": "^1.0.1"
       }
     },
     "extend": {
@@ -1258,41 +1656,114 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "extensible-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/extensible-error/-/extensible-error-1.0.2.tgz",
+      "integrity": "sha512-kXU1FiTsGT8PyMKtFM074RK/VBpzwuQJicAHqBpsPDeTXBQiSALPjkjKXlyKdG/GP6lR7bBaEkq8qdoO2geu9g=="
+    },
     "external-editor": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
       "dev": true,
       "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
       }
     },
     "extglob": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "requires": {
-        "is-extglob": "^1.0.0"
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
       }
     },
-    "eyes": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -1357,19 +1828,13 @@
       }
     },
     "file-entry-cache": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "^2.0.1"
       }
-    },
-    "filename-regex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
     },
     "fileset": {
       "version": "2.0.3",
@@ -1392,15 +1857,24 @@
       }
     },
     "fill-range": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^3.0.0",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "find-root": {
@@ -1419,54 +1893,49 @@
       }
     },
     "findup-sync": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
-      "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+      "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "requires": {
-        "detect-file": "^0.1.0",
-        "is-glob": "^2.0.1",
-        "micromatch": "^2.3.7",
-        "resolve-dir": "^0.1.0"
+        "detect-file": "^1.0.0",
+        "is-glob": "^3.1.0",
+        "micromatch": "^3.0.4",
+        "resolve-dir": "^1.0.1"
       }
     },
     "fined": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.1.tgz",
-      "integrity": "sha512-jQp949ZmEbiYHk3gkbdtpJ0G1+kgtLQBNdP5edFP7Fh+WAYceLQz6yO1SBj72Xkg8GVyTB3bBzAYrHJVh5Xd5g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
+      "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
       "requires": {
         "expand-tilde": "^2.0.2",
         "is-plain-object": "^2.0.3",
         "object.defaults": "^1.1.0",
         "object.pick": "^1.2.0",
         "parse-filepath": "^1.0.1"
-      },
-      "dependencies": {
-        "expand-tilde": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-          "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-          "requires": {
-            "homedir-polyfill": "^1.0.1"
-          }
-        }
       }
     },
     "flagged-respawn": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
-      "integrity": "sha1-/xke3c1wiKZ1smEP/8l2vpuAdLU="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
+      "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q=="
     },
     "flat-cache": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
-      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "graceful-fs": "^4.1.2",
-        "rimraf": "~2.6.2",
-        "write": "^0.2.1"
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
       }
+    },
+    "flatted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+      "dev": true
     },
     "for-each": {
       "version": "0.3.3",
@@ -1483,17 +1952,35 @@
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
     "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+      "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
       "requires": {
         "for-in": "^1.0.1"
       }
     },
-    "fs-exists-sync": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -1513,16 +2000,24 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
-    "generic-pool": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.6.1.tgz",
-      "integrity": "sha512-iMmD/pY4q0+V+f8o4twE9JPeqfNuX+gJAaIPB3B0W1lFkBOtTxBo6B0HxHPgGhzQA8jego7EWopcYq/UDJO2KA=="
-    },
     "get-stdin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
       "dev": true
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "glob": {
       "version": "7.1.3",
@@ -1538,41 +2033,36 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
-      }
-    },
     "glob-parent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
       }
     },
     "global-modules": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
-      "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "requires": {
-        "global-prefix": "^0.1.4",
-        "is-windows": "^0.2.0"
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
       }
     },
     "global-prefix": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-      "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "requires": {
-        "homedir-polyfill": "^1.0.0",
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
         "ini": "^1.3.4",
-        "is-windows": "^0.2.0",
-        "which": "^1.2.12"
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
       }
     },
     "globals": {
@@ -1755,6 +2245,7 @@
           "integrity": "sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==",
           "requires": {
             "hoek": "6.x.x",
+            "isemail": "3.x.x",
             "topo": "3.x.x"
           }
         },
@@ -1879,6 +2370,20 @@
         }
       }
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -1898,15 +2403,44 @@
       }
     },
     "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
     },
     "homedir-polyfill": {
       "version": "1.0.3",
@@ -1921,6 +2455,16 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -1942,6 +2486,34 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
+    },
+    "ilp-packet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-2.2.0.tgz",
+      "integrity": "sha1-qHJcwmMxxuLGU1OKEGPVUBQwXjE=",
+      "requires": {
+        "bignumber.js": "^5.0.0",
+        "extensible-error": "^1.0.2",
+        "long": "^3.2.0",
+        "oer-utils": "^1.3.2"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
+          "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg=="
+        }
+      }
+    },
+    "import-fresh": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+      "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -1970,39 +2542,56 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
-      "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
+      "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
         "cli-cursor": "^2.1.0",
         "cli-width": "^2.0.0",
-        "external-editor": "^2.1.0",
+        "external-editor": "^3.0.3",
         "figures": "^2.0.0",
-        "lodash": "^4.3.0",
+        "lodash": "^4.17.12",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
-        "rxjs": "^5.5.2",
+        "rxjs": "^6.4.0",
         "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
+        "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -2028,12 +2617,23 @@
       "requires": {
         "is-relative": "^1.0.0",
         "is-windows": "^1.0.1"
+      }
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "requires": {
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
-        "is-windows": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
         }
       }
     },
@@ -2053,23 +2653,45 @@
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
     },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
-    "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
-    },
-    "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+        }
       }
     },
     "is-extendable": {
@@ -2078,9 +2700,9 @@
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-finite": {
       "version": "1.0.2",
@@ -2098,19 +2720,29 @@
       "dev": true
     },
     "is-glob": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "^2.1.0"
       }
     },
     "is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "requires": {
         "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-object": {
@@ -2131,24 +2763,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
         "isobject": "^3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        }
       }
-    },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
-    },
-    "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
     },
     "is-promise": {
       "version": "2.1.0",
@@ -2173,12 +2788,6 @@
         "is-unc-path": "^1.0.0"
       }
     },
-    "is-resolvable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-      "dev": true
-    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -2192,6 +2801,11 @@
       "requires": {
         "has-symbols": "^1.0.0"
       }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-unc-path": {
       "version": "1.0.0",
@@ -2208,14 +2822,29 @@
       "dev": true
     },
     "is-windows": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-      "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
     },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isemail": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+      "requires": {
+        "punycode": "2.x.x"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        }
+      }
     },
     "isexe": {
       "version": "2.0.0",
@@ -2223,12 +2852,9 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "requires": {
-        "isarray": "1.0.0"
-      }
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isstream": {
       "version": "0.1.2",
@@ -2373,12 +2999,6 @@
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
       "dev": true
     },
-    "js-string-escape": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-      "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
-      "optional": true
-    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -2395,6 +3015,11 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
     "jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
@@ -2407,11 +3032,15 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -2419,19 +3048,65 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
     "jsx-ast-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
-      "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
+      "integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.0.3"
+        "array-includes": "^3.0.3",
+        "object.assign": "^4.1.0"
       }
     },
     "just-extend": {
@@ -2440,37 +3115,72 @@
       "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
       "dev": true
     },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
       "requires": {
-        "is-buffer": "^1.1.5"
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
       }
     },
-    "knex": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-0.14.2.tgz",
-      "integrity": "sha1-87P+HqBxGvhCdwEAdoryG/y8uuo=",
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
       "requires": {
-        "babel-runtime": "^6.23.0",
-        "bluebird": "^3.4.6",
-        "chalk": "2.3.0",
-        "commander": "^2.2.0",
-        "debug": "3.1.0",
-        "generic-pool": "^3.1.7",
-        "inherits": "~2.0.1",
-        "interpret": "^1.0.4",
-        "liftoff": "2.3.0",
-        "lodash": "^4.6.0",
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "kind-of": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+    },
+    "knex": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-0.16.3.tgz",
+      "integrity": "sha512-jGTOBW8b7exaBPfCKJSlv5q320IvWw9hEdtnURtbb0k3HusfZrR4UYiEewem8Nl7VqJILoCj99SjCK3W54UNPg==",
+      "requires": {
+        "@babel/polyfill": "^7.0.0",
+        "@types/bluebird": "^3.5.25",
+        "bluebird": "^3.5.3",
+        "chalk": "2.4.1",
+        "commander": "^2.19.0",
+        "debug": "4.1.0",
+        "inherits": "~2.0.3",
+        "interpret": "^1.1.0",
+        "liftoff": "2.5.0",
+        "lodash": "^4.17.11",
         "minimist": "1.2.0",
-        "mkdirp": "^0.5.0",
+        "mkdirp": "^0.5.1",
         "pg-connection-string": "2.0.0",
-        "readable-stream": "2.3.3",
-        "safe-buffer": "^5.0.1",
+        "tarn": "^1.1.4",
         "tildify": "1.2.0",
-        "uuid": "^3.0.0",
-        "v8flags": "^3.0.0"
+        "uuid": "^3.3.2",
+        "v8flags": "^3.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "kuler": {
@@ -2492,17 +3202,16 @@
       }
     },
     "liftoff": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
-      "integrity": "sha1-qY8v9nGD2Lp8+soQVIvX/wVQs4U=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
+      "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
       "requires": {
         "extend": "^3.0.0",
-        "findup-sync": "^0.4.2",
+        "findup-sync": "^2.0.0",
         "fined": "^1.0.1",
-        "flagged-respawn": "^0.3.2",
-        "lodash.isplainobject": "^4.0.4",
-        "lodash.isstring": "^4.0.1",
-        "lodash.mapvalues": "^4.4.0",
+        "flagged-respawn": "^1.0.0",
+        "is-plain-object": "^2.0.4",
+        "object.map": "^1.0.0",
         "rechoir": "^0.6.2",
         "resolve": "^1.1.7"
       }
@@ -2540,7 +3249,28 @@
     "lodash": {
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+      "dev": true
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
@@ -2552,10 +3282,10 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
-    "lodash.mapvalues": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "logform": {
       "version": "2.1.2",
@@ -2570,9 +3300,9 @@
       },
       "dependencies": {
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -2581,6 +3311,11 @@
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.1.0.tgz",
       "integrity": "sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==",
       "dev": true
+    },
+    "long": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -2601,15 +3336,26 @@
         "yallist": "^2.1.2"
       }
     },
+    "make-iterator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
+      "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
+      "requires": {
+        "kind-of": "^6.0.2"
+      }
+    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
-    "math-random": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
-      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
     },
     "memorystream": {
       "version": "0.3.1",
@@ -2633,23 +3379,36 @@
       }
     },
     "micromatch": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      }
+    },
+    "mime-db": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+    },
+    "mime-types": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "requires": {
+        "mime-db": "1.40.0"
       }
     },
     "mimic-fn": {
@@ -2671,6 +3430,25 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -2708,6 +3486,64 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "mysql": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.16.0.tgz",
+      "integrity": "sha512-dPbN2LHonQp7D5ja5DJXNbCLe/HRdu+f3v61aguzNRQIrmZLOeRoymBYyeThrR6ug+FqzDL95Gc9maqZUJS+Gw==",
+      "requires": {
+        "bignumber.js": "4.1.0",
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2",
+        "sqlstring": "2.3.1"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -2766,14 +3602,6 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "requires": {
-        "remove-trailing-separator": "^1.0.1"
       }
     },
     "npm-audit-resolver": {
@@ -2884,11 +3712,44 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
     },
     "object-inspect": {
       "version": "1.6.0",
@@ -2902,6 +3763,34 @@
       "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
       "dev": true
     },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      },
+      "dependencies": {
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        }
+      }
+    },
     "object.defaults": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
@@ -2911,30 +3800,39 @@
         "array-slice": "^1.0.0",
         "for-own": "^1.0.0",
         "isobject": "^3.0.0"
-      },
-      "dependencies": {
-        "for-own": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-          "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-          "requires": {
-            "for-in": "^1.0.1"
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        }
       }
     },
-    "object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+    "object.entries": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
+      "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.11.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1"
+      }
+    },
+    "object.map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
+      "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+      "requires": {
+        "for-own": "^1.0.0",
+        "make-iterator": "^1.0.0"
       }
     },
     "object.pick": {
@@ -2943,14 +3841,24 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
         "isobject": "^3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        }
       }
+    },
+    "object.values": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "oer-utils": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-1.3.4.tgz",
+      "integrity": "sha1-sqmtvJK8GRVaKgDwRWg9Hm1KyCM="
     },
     "once": {
       "version": "1.4.0",
@@ -3060,6 +3968,15 @@
       "integrity": "sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc=",
       "optional": true
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "parse-filepath": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
@@ -3068,17 +3985,6 @@
         "is-absolute": "^1.0.0",
         "map-cache": "^0.2.0",
         "path-root": "^0.1.1"
-      }
-    },
-    "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
       }
     },
     "parse-json": {
@@ -3096,6 +4002,17 @@
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
     },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -3106,12 +4023,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "path-is-inside": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-key": {
@@ -3163,6 +4074,11 @@
       "requires": {
         "pify": "^3.0.0"
       }
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pg": {
       "version": "7.8.0",
@@ -3229,18 +4145,6 @@
       "integrity": "sha512-hod2zYQxM8Gt482q+qONGTYcg/qVcV32VHVPtktbBJs0us3Dj7xibISw0BAAXVMCzt8A/jhfJvpZaxUlqtqs0g==",
       "optional": true
     },
-    "pg-types": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
-      "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
-      "optional": true,
-      "requires": {
-        "postgres-array": "~1.0.0",
-        "postgres-bytea": "~1.0.0",
-        "postgres-date": "~1.0.0",
-        "postgres-interval": "^1.1.0"
-      }
-    },
     "pgpass": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
@@ -3263,13 +4167,83 @@
       "dev": true
     },
     "pkg-conf": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
-      "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
       "dev": true,
       "requires": {
-        "find-up": "^2.0.0",
-        "load-json-file": "^4.0.0"
+        "find-up": "^3.0.0",
+        "load-json-file": "^5.2.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+          "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.15",
+            "parse-json": "^4.0.0",
+            "pify": "^4.0.1",
+            "strip-bom": "^3.0.0",
+            "type-fest": "^0.3.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
       }
     },
     "pkg-config": {
@@ -3292,17 +4266,10 @@
         "find-up": "^2.1.0"
       }
     },
-    "pluralize": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-      "dev": true
-    },
-    "postgres-array": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.3.tgz",
-      "integrity": "sha512-5wClXrAP0+78mcsNX3/ithQ5exKvCyK5lr5NEEEeGwwM6NJdQgzIJBVxLvRW+huFpX92F2QnZ5CcokH0VhK2qQ==",
-      "optional": true
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postgres-bytea": {
       "version": "1.0.0",
@@ -3364,15 +4331,11 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
-    "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
-    },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -3392,23 +4355,23 @@
       }
     },
     "proxyquire": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.0.tgz",
-      "integrity": "sha512-kptdFArCfGRtQFv3Qwjr10lwbEV0TBJYvfqzhwucyfEXqVgmnAkyEw/S3FYzR5HI9i5QOq4rcqQjZ6AlknlCDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.1.tgz",
+      "integrity": "sha512-LXZGUxkFTZzPHKBmL3CMYtYIEKuz6XiR3DZ3FZ1wYP7ueXbz2NW+9AdigNzeLIf8vmuhVCwG2F5BvonXK5LhHA==",
       "dev": true,
       "requires": {
         "fill-keys": "^1.0.2",
-        "module-not-found-error": "^1.0.0",
-        "resolve": "~1.8.1"
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
       },
       "dependencies": {
         "resolve": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-          "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+          "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.5"
+            "path-parse": "^1.0.6"
           }
         }
       }
@@ -3419,39 +4382,25 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
+    "psl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
+      "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA=="
+    },
     "punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-      "dev": true
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
-    },
-    "randomatic": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
-      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
-      "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-        }
-      }
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "rc": {
       "version": "1.2.8",
@@ -3465,9 +4414,9 @@
       }
     },
     "react-is": {
-      "version": "16.8.3",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.3.tgz",
-      "integrity": "sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==",
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
       "dev": true
     },
     "read": {
@@ -3559,6 +4508,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3580,14 +4530,16 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
     },
-    "regex-cache": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "regexpp": {
@@ -3595,11 +4547,6 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
-    },
-    "remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "repeat-element": {
       "version": "1.1.3",
@@ -3620,14 +4567,56 @@
         "is-finite": "^1.0.0"
       }
     },
-    "require-uncached": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+      "requires": {
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+      "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+      "requires": {
+        "request-promise-core": "1.1.2",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
       }
     },
     "resolve": {
@@ -3639,19 +4628,24 @@
       }
     },
     "resolve-dir": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
-      "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "requires": {
-        "expand-tilde": "^1.2.2",
-        "global-modules": "^0.2.3"
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
       }
     },
     "resolve-from": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -3671,6 +4665,11 @@
       "requires": {
         "through": "~2.3.4"
       }
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "rimraf": {
       "version": "2.6.3",
@@ -3697,12 +4696,12 @@
       "dev": true
     },
     "rxjs": {
-      "version": "5.5.12",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
       "dev": true,
       "requires": {
-        "symbol-observable": "1.0.1"
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -3710,11 +4709,18 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sax": {
       "version": "1.2.1",
@@ -3726,6 +4732,27 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
       "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
+    },
+    "set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -3801,19 +4828,142 @@
       }
     },
     "slice-ansi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
       "dev": true,
       "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "requires": {
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
     "spawn-shell": {
       "version": "2.1.0",
@@ -3877,6 +5027,14 @@
         "through": "2"
       }
     },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
     "sprintf": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.5.tgz",
@@ -3889,39 +5047,91 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "sqlstring": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
+      "integrity": "sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A="
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+        }
+      }
+    },
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "standard": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/standard/-/standard-12.0.1.tgz",
-      "integrity": "sha512-UqdHjh87OG2gUrNCSM4QRLF5n9h3TFPwrCNyVlkqu31Hej0L/rc8hzKqVvkb2W3x0WMq7PzZdkLfEcBhVOR6lg==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-13.0.2.tgz",
+      "integrity": "sha512-tcdJc7Oa+ZFpIcYqNaV3kG3Ikqk1Ir5dCn8vaiLWvDcXdRGvQVQGbTqW/3y4RPEHXGBXoZZRQbb6VbSGx+0aqg==",
       "dev": true,
       "requires": {
-        "eslint": "~5.4.0",
-        "eslint-config-standard": "12.0.0",
-        "eslint-config-standard-jsx": "6.0.2",
-        "eslint-plugin-import": "~2.14.0",
-        "eslint-plugin-node": "~7.0.1",
-        "eslint-plugin-promise": "~4.0.0",
-        "eslint-plugin-react": "~7.11.1",
+        "eslint": "~6.0.1",
+        "eslint-config-standard": "13.0.1",
+        "eslint-config-standard-jsx": "7.0.0",
+        "eslint-plugin-import": "~2.18.0",
+        "eslint-plugin-node": "~9.1.0",
+        "eslint-plugin-promise": "~4.2.1",
+        "eslint-plugin-react": "~7.14.2",
         "eslint-plugin-standard": "~4.0.0",
-        "standard-engine": "~9.0.0"
+        "standard-engine": "~11.0.1"
       }
     },
     "standard-engine": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-9.0.0.tgz",
-      "integrity": "sha512-ZfNfCWZ2Xq67VNvKMPiVMKHnMdvxYzvZkf1AH8/cw2NLDBm5LRsxMqvEJpsjLI/dUosZ3Z1d6JlHDp5rAvvk2w==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-11.0.1.tgz",
+      "integrity": "sha512-WZQ5PpEDfRzPFk+H9xvKVQPQIxKnAQB2cb2Au4NyTCtdw5R0pyMBUZLbPXyFjnlhe8Ae+zfNrWU4m6H5b7cEAg==",
       "dev": true,
       "requires": {
-        "deglob": "^2.1.0",
-        "get-stdin": "^6.0.0",
+        "deglob": "^3.0.0",
+        "get-stdin": "^7.0.0",
         "minimist": "^1.1.0",
-        "pkg-conf": "^2.0.0"
+        "pkg-conf": "^3.1.0"
       }
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "string-width": {
       "version": "2.1.1",
@@ -3976,6 +5186,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -4004,31 +5215,69 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-      "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
-        "has-flag": "^2.0.0"
+        "has-flag": "^3.0.0"
       }
     },
-    "symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
-      "dev": true
-    },
     "table": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
-      "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.4.tgz",
+      "integrity": "sha512-IIfEAUx5QlODLblLrGTTLJA7Tk0iLSGBvgY8essPRVNGHAzThujww1YqHLs6h3HfTg55h++RzLHH5Xw/rfv+mg==",
       "dev": true,
       "requires": {
-        "ajv": "^6.0.1",
-        "ajv-keywords": "^3.0.0",
-        "chalk": "^2.1.0",
-        "lodash": "^4.17.4",
-        "slice-ansi": "1.0.0",
-        "string-width": "^2.1.1"
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "tap-parser": {
@@ -4068,9 +5317,9 @@
       }
     },
     "tap-xunit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tap-xunit/-/tap-xunit-2.3.0.tgz",
-      "integrity": "sha512-YVsURNvn1wfVUWb5wjansxhfbfeo2hOBTUbVgZoaMO8lyZzpiSi9IiZTZ7JG56m6A49LeWjfJIx/SnAre41V/A==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tap-xunit/-/tap-xunit-2.4.1.tgz",
+      "integrity": "sha512-qcZStDtjjYjMKAo7QNiCtOW256g3tuSyCSe5kNJniG1Q2oeOExJq4vm8CwboHZURpkXAHvtqMl4TVL7mcbMVVA==",
       "dev": true,
       "requires": {
         "duplexer": "~0.1.1",
@@ -4082,9 +5331,9 @@
       },
       "dependencies": {
         "process-nextick-args": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
           "dev": true
         },
         "string_decoder": {
@@ -4147,21 +5396,21 @@
       }
     },
     "tape": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-4.10.0.tgz",
-      "integrity": "sha512-3PgdF0vcZ1t7HEYbpTXdo58KXi19QCGcZfj07A53M2DH14P2Fw3cB3f9pF7e/Br2z+PQm7xlvhjzHH3D8ti99g==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.11.0.tgz",
+      "integrity": "sha512-yixvDMX7q7JIs/omJSzSZrqulOV51EC9dK8dM0TzImTIkHWfe2/kFyL5v+d9C+SrCMaICk59ujsqFAVidDqDaA==",
       "dev": true,
       "requires": {
         "deep-equal": "~1.0.1",
         "defined": "~1.0.0",
         "for-each": "~0.3.3",
         "function-bind": "~1.1.1",
-        "glob": "~7.1.3",
+        "glob": "~7.1.4",
         "has": "~1.0.3",
-        "inherits": "~2.0.3",
+        "inherits": "~2.0.4",
         "minimist": "~1.2.0",
         "object-inspect": "~1.6.0",
-        "resolve": "~1.7.1",
+        "resolve": "~1.11.1",
         "resumer": "~0.0.0",
         "string.prototype.trim": "~1.1.2",
         "through": "~2.3.8"
@@ -4179,13 +5428,33 @@
           "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
           "dev": true
         },
-        "resolve": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-          "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.5"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+          "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
           }
         }
       }
@@ -4220,6 +5489,11 @@
           }
         }
       }
+    },
+    "tarn": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/tarn/-/tarn-1.1.5.tgz",
+      "integrity": "sha512-PMtJ3HCLAZeedWjJPgGnCvcphbCOMbtZpjKgLq3qM5Qq9aQud+XHrL0WlrlgnTyS8U+jrjGbEXprFcQrxPy52g=="
     },
     "text-hex": {
       "version": "1.0.0",
@@ -4305,6 +5579,60 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "requires": {
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
+      }
+    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -4315,6 +5643,20 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
+    },
+    "tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "tweetnacl": {
       "version": "1.0.1",
@@ -4339,6 +5681,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "type-fest": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
       "dev": true
     },
     "typedarray": {
@@ -4379,17 +5727,63 @@
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
     },
+    "union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      }
+    },
     "uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+        }
+      }
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       },
@@ -4397,10 +5791,14 @@
         "punycode": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-          "dev": true
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         }
       }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
     "url": {
       "version": "0.10.3",
@@ -4411,6 +5809,11 @@
         "punycode": "1.3.2",
         "querystring": "0.2.0"
       }
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -4428,9 +5831,9 @@
       "integrity": "sha512-Gr1q2k40LpF8CokcnQFjPDsdslzJbTCTBG5xQIEflUov431gFkY5KduiGIeKYAamkQnNn4IfdHJbLnl9Bib8TQ=="
     },
     "v8flags": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.2.tgz",
-      "integrity": "sha512-MtivA7GF24yMPte9Rp/BWGCYQNaUj86zeYxV/x2RRJMKagImbbv3u8iJC57lNhWLPcGLJmHcHmFWkNsplbbLWw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
+      "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
       "requires": {
         "homedir-polyfill": "^1.0.1"
       }
@@ -4443,6 +5846,16 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
       }
     },
     "which": {
@@ -4470,9 +5883,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -4499,9 +5912,9 @@
       },
       "dependencies": {
         "process-nextick-args": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
         "readable-stream": {
           "version": "2.3.6",
@@ -4540,20 +5953,20 @@
       "dev": true
     },
     "write": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
       }
     },
     "ws": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.3.tgz",
-      "integrity": "sha512-tbSxiT+qJI223AP4iLfQbkbxkwdFcneYinM2+x46Gx2wgvbaOMO36czfdfVUBRTHvzAMRhDd98sA5d/BuWbQdg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.1.tgz",
+      "integrity": "sha512-o41D/WmDeca0BqYhsr3nJzQyg9NF5X8l/UdnFNux9cS3lwB+swm8qGWX5rn+aD6xfBU3rGmtHij7g7x6LxFU3A==",
       "requires": {
-        "async-limiter": "~1.0.0"
+        "async-limiter": "^1.0.0"
       }
     },
     "xml2js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/forensic-logging-sidecar",
-  "version": "5.3.0",
+  "version": "7.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -558,6 +558,12 @@
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
+    "camelcase": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+      "dev": true
+    },
     "chalk": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
@@ -749,6 +755,12 @@
       "requires": {
         "strip-bom": "^2.0.0"
       }
+    },
+    "default-shell": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/default-shell/-/default-shell-1.0.1.tgz",
+      "integrity": "sha1-dSMEvdxhdPSespy5iP7qC4gTyLw=",
+      "dev": true
     },
     "define-properties": {
       "version": "1.1.3",
@@ -2107,6 +2119,12 @@
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
       "dev": true
     },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -2605,6 +2623,15 @@
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
+    "merge-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-1.0.1.tgz",
+      "integrity": "sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.1"
+      }
+    },
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
@@ -2749,6 +2776,54 @@
         "remove-trailing-separator": "^1.0.1"
       }
     },
+    "npm-audit-resolver": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/npm-audit-resolver/-/npm-audit-resolver-1.5.0.tgz",
+      "integrity": "sha512-pOatk9mNIVqljbjlW8MqpeBWzF9TP9x7RMIyG+Z8i1RW0180w2h/+fhYruDzzLMLwe/FlLlk6uKSygUBVzjHFA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "concat-stream": "^1.6.2",
+        "read": "^1.0.7",
+        "semver": "^5.5.0",
+        "spawn-shell": "^2.1.0",
+        "yargs-parser": "^10.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "npm-run-all": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
@@ -2792,6 +2867,15 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
       }
     },
     "number-is-nan": {
@@ -3386,6 +3470,15 @@
       "integrity": "sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==",
       "dev": true
     },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "dev": true,
+      "requires": {
+        "mute-stream": "~0.0.4"
+      }
+    },
     "read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -3721,6 +3814,17 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
+    },
+    "spawn-shell": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spawn-shell/-/spawn-shell-2.1.0.tgz",
+      "integrity": "sha512-mjlYAQbZPHd4YsoHEe+i0Xbp9sJefMKN09JPp80TqrjC5NSuo+y1RG3NBireJlzl1dDV2NIkIfgS6coXtyqN/A==",
+      "dev": true,
+      "requires": {
+        "default-shell": "^1.0.1",
+        "merge-options": "~1.0.1",
+        "npm-run-path": "^2.0.2"
+      }
     },
     "spawn-sync": {
       "version": "1.0.15",
@@ -4478,6 +4582,15 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "yargs-parser": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+      "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^4.1.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "audit:check": "SHELL=sh check-audit"
   },
   "dependencies": {
-    "@mojaloop/central-services-database": "5.2.1",
+    "@mojaloop/central-services-database": "0.4.0",
     "@mojaloop/central-services-error-handling": "7.1.2",
     "@mojaloop/central-services-shared": "6.4.1",
     "bitsyntax": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/forensic-logging-sidecar",
-  "version": "5.3.0",
+  "version": "7.1.0",
   "description": "Sidecar service to save forensic logs.",
   "license": "Apache-2.0",
   "contributors": [
@@ -52,7 +52,9 @@
     "docker:publish ": "run-s docker:build:version docker:push:version",
     "docker:publish:test": "run-s docker:build:test docker:push:test",
     "docker:publish:snapshot": "run-s docker:build:snapshot docker:push:snapshot",
-    "docker:publish:latest": "run-s docker:build:latest docker:push:latest"
+    "docker:publish:latest": "run-s docker:build:latest docker:push:latest",
+    "audit:resolve": "SHELL=sh resolve-audit",
+    "audit:check": "SHELL=sh check-audit"
   },
   "dependencies": {
     "@mojaloop/central-services-database": "0.4.0",
@@ -76,6 +78,7 @@
     "aws-sdk": "2.401.0",
     "faucet": "0.0.1",
     "istanbul": "1.1.0-alpha.1",
+    "npm-audit-resolver": "1.5.0",
     "pre-commit": "1.2.2",
     "npm-run-all": "4.1.5",
     "proxyquire": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -57,11 +57,11 @@
     "audit:check": "SHELL=sh check-audit"
   },
   "dependencies": {
-    "@mojaloop/central-services-database": "0.4.0",
-    "@mojaloop/central-services-error-handling": "5.2.0",
-    "@mojaloop/central-services-shared": "0.4.0",
+    "@mojaloop/central-services-database": "5.2.1",
+    "@mojaloop/central-services-error-handling": "7.1.2",
+    "@mojaloop/central-services-shared": "6.4.1",
     "bitsyntax": "0.1.0",
-    "bluebird": "3.5.3",
+    "bluebird": "3.5.5",
     "hapi": "18.1.0",
     "moment": "2.24.0",
     "node-aes-cmac": "0.1.1",
@@ -69,23 +69,23 @@
     "tweetnacl": "1.0.1",
     "tweetnacl-util": "0.15.0",
     "uuid4": "1.1.4",
-    "ws": "6.1.3"
+    "ws": "7.1.1"
   },
   "optionalDependencies": {
     "pg": "7.8.0"
   },
   "devDependencies": {
-    "aws-sdk": "2.401.0",
+    "aws-sdk": "2.496.0",
     "faucet": "0.0.1",
     "istanbul": "1.1.0-alpha.1",
     "npm-audit-resolver": "1.5.0",
     "pre-commit": "1.2.2",
     "npm-run-all": "4.1.5",
-    "proxyquire": "2.1.0",
+    "proxyquire": "2.1.1",
     "sinon": "7.2.3",
-    "standard": "12.0.1",
-    "tap-xunit": "2.3.0",
-    "tape": "4.10.0",
+    "standard": "13.0.2",
+    "tap-xunit": "2.4.1",
+    "tape": "4.11.0",
     "tapes": "4.1.0"
   }
 }

--- a/src/domain/batch/index.js
+++ b/src/domain/batch/index.js
@@ -32,7 +32,7 @@ exports.findForService = (serviceName, startTime, endTime) => {
 }
 
 const buildBatchData = (events) => {
-  let batchData = events.map(e => {
+  const batchData = events.map(e => {
     return {
       row: EventService.getSignableEvent(e),
       signature: e.signature

--- a/src/domain/event/index.js
+++ b/src/domain/event/index.js
@@ -10,7 +10,7 @@ exports.create = (sidecarId, sequence, message, signingKey) => {
   const created = Moment.utc()
   const eventId = Uuid()
 
-  let event = { eventId, sidecarId, sequence, message, created }
+  const event = { eventId, sidecarId, sequence, message, created }
   event.signature = createEventSignature(event, signingKey)
 
   return Model.create(event)

--- a/src/domain/event/model.js
+++ b/src/domain/event/model.js
@@ -7,11 +7,11 @@ exports.create = (event) => {
 }
 
 exports.getUnbatchedEvents = (eventIds) => {
-  return Db.events.find({ 'eventId': eventIds, 'batchId': null }, { order: 'sequence asc' })
+  return Db.events.find({ eventId: eventIds, batchId: null }, { order: 'sequence asc' })
 }
 
 exports.getEventCount = (sidecarId, { startTime = null, endTime = null } = {}) => {
-  let criteria = { sidecarId }
+  const criteria = { sidecarId }
 
   if (startTime) {
     criteria['created >='] = startTime
@@ -24,5 +24,5 @@ exports.getEventCount = (sidecarId, { startTime = null, endTime = null } = {}) =
 }
 
 exports.updateEvents = (eventIds, fields) => {
-  return Db.events.update({ 'eventId': eventIds }, fields)
+  return Db.events.update({ eventId: eventIds }, fields)
 }

--- a/src/kms/index.js
+++ b/src/kms/index.js
@@ -109,7 +109,7 @@ class KmsConnection extends EventEmitter {
   }
 
   sendBatch (batch) {
-    return this.request('batch', { 'id': batch.batchId, 'signature': batch.signature })
+    return this.request('batch', { id: batch.batchId, signature: batch.signature })
   }
 
   request (method, params) {
@@ -155,10 +155,10 @@ class KmsConnection extends EventEmitter {
 
   // Websocket event handlers
   _onWebSocketMessage (data) {
-    let parsed = JSON.parse(data)
+    const parsed = JSON.parse(data)
 
     if (this._isJsonRpc(parsed)) {
-      let id = parsed.id
+      const id = parsed.id
 
       if (this._isJsonRpcRequest(parsed)) {
         // This is a request from the KMS, emit the appropriate event.

--- a/src/kms/requests/index.js
+++ b/src/kms/requests/index.js
@@ -14,7 +14,7 @@ class Requests {
   start (func) {
     const id = this._generateId()
 
-    let request = this._existing[id] = Request.create()
+    const request = this._existing[id] = Request.create()
     request.build(() => func(id), this._timeout, () => delete this._existing[id])
 
     return this._getPromise(id)

--- a/src/kms/websocket.js
+++ b/src/kms/websocket.js
@@ -59,7 +59,7 @@ class WebSocket extends EventEmitter {
         case 'ECONNREFUSED':
           Logger.info(`Error connecting to KMS, attempting to connect after sleeping ${this._reconnectInterval}ms`)
 
-          let self = this
+          const self = this
           this._reconnectTimerId = setTimeout(() => {
             self._connect()
           }, this._reconnectInterval)

--- a/src/socket/connection.js
+++ b/src/socket/connection.js
@@ -7,7 +7,7 @@ class TcpConnection extends EventEmitter {
   constructor (socket) {
     super()
 
-    let self = this
+    const self = this
     self._socket = socket
     self._matcher = BitSyntax.matcher('len:32/big-unsigned, message:len/binary, rest/binary')
 
@@ -16,7 +16,7 @@ class TcpConnection extends EventEmitter {
     self._socket.on('data', data => {
       buffer = appendToBuffer(buffer, data)
       while (true) {
-        let parsed = self._matcher(buffer)
+        const parsed = self._matcher(buffer)
         if (!parsed) break
 
         self.emit('message', parsed.message)

--- a/src/socket/index.js
+++ b/src/socket/index.js
@@ -9,14 +9,14 @@ class SocketListener extends EventEmitter {
   constructor () {
     super()
 
-    let self = this
+    const self = this
     self._bound = false
     self._paused = false
     self._connections = []
 
     self._server = Net.createServer()
     self._server.on('connection', socket => {
-      let tcpConnection = TcpConnection.create(socket)
+      const tcpConnection = TcpConnection.create(socket)
       self._connections.push(tcpConnection)
 
       tcpConnection.on('message', self._onConnectionMessage.bind(self))

--- a/test/integration/domain/event/model.test.js
+++ b/test/integration/domain/event/model.test.js
@@ -76,7 +76,7 @@ Test('events model', modelTest => {
       P.all([SidecarModel.create(sidecar), SidecarModel.create(sidecar2)])
         .then(() => P.all([Model.create(event), Model.create(event2), Model.create(event3), Model.create(event4)]))
         .then(createdEvents => {
-          let batch = { sidecarId, batchId: Uuid(), data: '', signature: '', created }
+          const batch = { sidecarId, batchId: Uuid(), data: '', signature: '', created }
           BatchModel.create(batch)
             .then(createdBatch => Model.updateEvents([event3.eventId, event4.eventId], { batchId: createdBatch.batchId }))
             .then(() => {
@@ -157,7 +157,7 @@ Test('events model', modelTest => {
       SidecarModel.create(sidecar)
         .then(() => P.all([Model.create(event), Model.create(event2), Model.create(event3)]))
         .then(createdEvents => {
-          let batch = { sidecarId, batchId: Uuid(), data: '', signature: '', created }
+          const batch = { sidecarId, batchId: Uuid(), data: '', signature: '', created }
           BatchModel.create(batch)
             .then(createdBatch => {
               Model.updateEvents(createdEvents.map(x => x.eventId), { batchId: createdBatch.batchId })

--- a/test/unit/crypto/asymmetric.test.js
+++ b/test/unit/crypto/asymmetric.test.js
@@ -27,22 +27,22 @@ Test('Asymmetric crypto', asymmetricTest => {
 
   asymmetricTest.test('sign should', signTest => {
     signTest.test('create ED25519 signature as hex value', test => {
-      let privateKey = '107746ae1300174f7049e5988d0301dd76e57713d82b125df4161fc7be88bb780224bdab8a182a57793a465176b8ffd0546c5f171e3115185a57e95bc0ba5279'
-      let privateKeyBuffer = Buffer.from(privateKey, 'hex')
+      const privateKey = '107746ae1300174f7049e5988d0301dd76e57713d82b125df4161fc7be88bb780224bdab8a182a57793a465176b8ffd0546c5f171e3115185a57e95bc0ba5279'
+      const privateKeyBuffer = Buffer.from(privateKey, 'hex')
 
-      let message = 'test message'
-      let messageBuffer = Buffer.from(message, 'utf8')
+      const message = 'test message'
+      const messageBuffer = Buffer.from(message, 'utf8')
 
       CryptoUtil.hexToBuffer.returns(privateKeyBuffer)
       TweetNaclUtil.decodeUTF8.returns(messageBuffer)
 
-      let signature = 'signature'
-      let hexSignature = '12bad535abf80ffc5bb40437b244e66101c8bf736e3bb22e297bbddc5a401fa5fe32dccd5b2d24a475efae51c751edaf742ee9168b4194370c7eb5097dcd0e0e35663637346231352d323339362d346635332d393961622d306234303631646265333434'
+      const signature = 'signature'
+      const hexSignature = '12bad535abf80ffc5bb40437b244e66101c8bf736e3bb22e297bbddc5a401fa5fe32dccd5b2d24a475efae51c751edaf742ee9168b4194370c7eb5097dcd0e0e35663637346231352d323339362d346635332d393961622d306234303631646265333434'
 
       TweetNacl.sign = { detached: sandbox.stub().returns(signature) }
       CryptoUtil.uint8ArrayToHex.returns(hexSignature)
 
-      let s = Asymmetric.sign(message, privateKey)
+      const s = Asymmetric.sign(message, privateKey)
       test.ok(CryptoUtil.hexToBuffer.calledWith(privateKey))
       test.ok(TweetNacl.sign.detached.calledWith(messageBuffer, privateKeyBuffer))
       test.ok(CryptoUtil.uint8ArrayToHex.calledWith(signature))

--- a/test/unit/crypto/symmetric.test.js
+++ b/test/unit/crypto/symmetric.test.js
@@ -29,16 +29,16 @@ Test('Symmetric crypto', symmetricTest => {
 
   symmetricTest.test('sign should', createTest => {
     createTest.test('create AES CMAC signature', test => {
-      let message = 'test message'
-      let signingKey = 'DFDE22A3276FC520A24FBE5534EDADFE080D78375C4530E038EFCF6CA699228A'
-      let signingKeyBuffer = Buffer.from(signingKey, 'hex')
+      const message = 'test message'
+      const signingKey = 'DFDE22A3276FC520A24FBE5534EDADFE080D78375C4530E038EFCF6CA699228A'
+      const signingKeyBuffer = Buffer.from(signingKey, 'hex')
 
       CryptoUtil.hexToBuffer.returns(signingKeyBuffer)
 
-      let signature = 'signature'
+      const signature = 'signature'
       aesCmacStub.returns(signature)
 
-      let s = Symmetric.sign(message, signingKey)
+      const s = Symmetric.sign(message, signingKey)
       test.ok(CryptoUtil.hexToBuffer.calledWith(signingKey))
       test.ok(aesCmacStub.calledWith(signingKeyBuffer, message))
       test.equal(s, signature)

--- a/test/unit/crypto/util.test.js
+++ b/test/unit/crypto/util.test.js
@@ -20,19 +20,19 @@ Test('Crypto utilities', cryptoUtilTest => {
 
   cryptoUtilTest.test('hexToBuffer should', hexBufferTest => {
     hexBufferTest.test('convert hex encoded key to buffer', test => {
-      let key = '107746ae1300174f7049e5988d0301dd76e57713d82b125df4161fc7be88bb780224bdab8a182a57793a465176b8ffd0546c5f171e3115185a57e95bc0ba5279'
-      let keyBuffer = Buffer.from(key, 'hex')
+      const key = '107746ae1300174f7049e5988d0301dd76e57713d82b125df4161fc7be88bb780224bdab8a182a57793a465176b8ffd0546c5f171e3115185a57e95bc0ba5279'
+      const keyBuffer = Buffer.from(key, 'hex')
 
-      let k = CryptoUtil.hexToBuffer(key)
+      const k = CryptoUtil.hexToBuffer(key)
       test.ok(k.equals(keyBuffer))
 
       test.end()
     })
 
     hexBufferTest.test('return value if already buffer', test => {
-      let keyBuffer = Buffer.from('107746ae1300174f7049e5988d0301dd76e57713d82b125df4161fc7be88bb780224bdab8a182a57793a465176b8ffd0546c5f171e3115185a57e95bc0ba5279', 'hex')
+      const keyBuffer = Buffer.from('107746ae1300174f7049e5988d0301dd76e57713d82b125df4161fc7be88bb780224bdab8a182a57793a465176b8ffd0546c5f171e3115185a57e95bc0ba5279', 'hex')
 
-      let k = CryptoUtil.hexToBuffer(keyBuffer)
+      const k = CryptoUtil.hexToBuffer(keyBuffer)
       test.equal(k, keyBuffer)
 
       test.end()
@@ -43,14 +43,14 @@ Test('Crypto utilities', cryptoUtilTest => {
 
   cryptoUtilTest.test('uint8ArrayToHex should', uintHexTest => {
     uintHexTest.test('conver UInt8Array to hex', test => {
-      let hex = '1f2f3f4f'
-      let uint8 = new Uint8Array(4)
+      const hex = '1f2f3f4f'
+      const uint8 = new Uint8Array(4)
       uint8[0] = 0x1f
       uint8[1] = 0x2f
       uint8[2] = 0x3f
       uint8[3] = 0x4f
 
-      let converted = CryptoUtil.uint8ArrayToHex(uint8)
+      const converted = CryptoUtil.uint8ArrayToHex(uint8)
       test.equal(converted, hex)
 
       test.end()

--- a/test/unit/domain/batch/index.test.js
+++ b/test/unit/domain/batch/index.test.js
@@ -28,7 +28,7 @@ Test('Batch service', serviceTest => {
 
     uuidStub = sandbox.stub()
 
-    Service = Proxyquire(`${src}/domain/batch`, { 'uuid4': uuidStub })
+    Service = Proxyquire(`${src}/domain/batch`, { uuid4: uuidStub })
 
     t.end()
   })
@@ -40,23 +40,23 @@ Test('Batch service', serviceTest => {
 
   serviceTest.test('create should', createTest => {
     createTest.test('create batch and update events', test => {
-      let sidecarId = Uuid()
-      let batchId = Uuid()
-      let eventIds = [1, 2]
-      let signingKey = 'DFDE22A3276FC520A24FBE5534EDADFE080D78375C4530E038EFCF6CA699228A'
-      let now = Moment()
+      const sidecarId = Uuid()
+      const batchId = Uuid()
+      const eventIds = [1, 2]
+      const signingKey = 'DFDE22A3276FC520A24FBE5534EDADFE080D78375C4530E038EFCF6CA699228A'
+      const now = Moment()
 
       uuidStub.returns(batchId)
 
-      let savedBatch = {}
+      const savedBatch = {}
       Model.create.returns(P.resolve(savedBatch))
 
-      let signature = 'signature'
+      const signature = 'signature'
       AsymmetricCrypto.sign.returns(signature)
 
       Moment.utc.returns(now)
 
-      let unbatchedEvents = [{ eventId: eventIds[0], sidecarId, sequence: 1, message: 'test1', signature: 'sig1', created: now }, { eventId: eventIds[1], sidecarId, sequence: 2, message: 'test2', signature: 'sig2', created: now }].map(e => {
+      const unbatchedEvents = [{ eventId: eventIds[0], sidecarId, sequence: 1, message: 'test1', signature: 'sig1', created: now }, { eventId: eventIds[1], sidecarId, sequence: 2, message: 'test2', signature: 'sig2', created: now }].map(e => {
         e.signable = { keyId: e.sidecarId, sequence: e.sequence, message: e.message, timestamp: e.created.toISOString() }
         return e
       })
@@ -66,7 +66,7 @@ Test('Batch service', serviceTest => {
       EventService.getUnbatchedEventsByIds.returns(P.resolve(unbatchedEvents))
       EventService.assignEventsToBatch.returns(P.resolve())
 
-      let batchData = JSON.stringify(unbatchedEvents.map(e => {
+      const batchData = JSON.stringify(unbatchedEvents.map(e => {
         return {
           row: e.signable,
           signature: e.signature
@@ -95,10 +95,10 @@ Test('Batch service', serviceTest => {
 
   serviceTest.test('findForService should', findForServiceTest => {
     findForServiceTest.test('find batches for timespan', test => {
-      let now = Moment()
-      let start = Moment(now).subtract(5, 'minutes')
+      const now = Moment()
+      const start = Moment(now).subtract(5, 'minutes')
 
-      let batches = [{ batchId: '1' }, { batchId: '2' }]
+      const batches = [{ batchId: '1' }, { batchId: '2' }]
       Model.findForService.returns(P.resolve(batches))
 
       const service = 'test-service'
@@ -114,10 +114,10 @@ Test('Batch service', serviceTest => {
     })
 
     findForServiceTest.test('convert dates to strings before calling model', test => {
-      let now = Moment()
-      let start = Moment(now).subtract(5, 'minutes')
+      const now = Moment()
+      const start = Moment(now).subtract(5, 'minutes')
 
-      let batches = [{ batchId: '1' }, { batchId: '2' }]
+      const batches = [{ batchId: '1' }, { batchId: '2' }]
       Model.findForService.returns(P.resolve(batches))
 
       const service = 'test-service'

--- a/test/unit/domain/batch/model.test.js
+++ b/test/unit/domain/batch/model.test.js
@@ -29,8 +29,8 @@ Test('Batches model', modelTest => {
 
   modelTest.test('create should', createTest => {
     createTest.test('save payload and return new batch', test => {
-      let payload = { batchId: 'event-id', sidecarId: 'sidecar-id', data: 'test data', signature: 'test' }
-      let insertedBatch = { batchId: payload.batchId }
+      const payload = { batchId: 'event-id', sidecarId: 'sidecar-id', data: 'test data', signature: 'test' }
+      const insertedBatch = { batchId: payload.batchId }
 
       Db.batches.insert.returns(P.resolve(insertedBatch))
 
@@ -47,21 +47,21 @@ Test('Batches model', modelTest => {
 
   modelTest.test('findForService should', findForServiceTest => {
     findForServiceTest.test('find sidecar batches for a service and timespan', test => {
-      let now = Moment.utc()
-      let start = Moment.utc(now).subtract(5, 'minutes')
+      const now = Moment.utc()
+      const start = Moment.utc(now).subtract(5, 'minutes')
 
-      let service = 'test-service'
-      let startTime = start.toISOString()
-      let endTime = start.toISOString()
+      const service = 'test-service'
+      const startTime = start.toISOString()
+      const endTime = start.toISOString()
 
-      let batches = [{ batchId: '1' }, { batchId: '2' }]
+      const batches = [{ batchId: '1' }, { batchId: '2' }]
 
-      let builderStub = sandbox.stub()
-      let whereStub = sandbox.stub()
-      let andWhere1Stub = sandbox.stub()
-      let andWhere2Stub = sandbox.stub()
-      let selectStub = sandbox.stub()
-      let orderByStub = sandbox.stub()
+      const builderStub = sandbox.stub()
+      const whereStub = sandbox.stub()
+      const andWhere1Stub = sandbox.stub()
+      const andWhere2Stub = sandbox.stub()
+      const selectStub = sandbox.stub()
+      const orderByStub = sandbox.stub()
 
       builderStub.join = sandbox.stub()
 

--- a/test/unit/domain/batch/tracker.test.js
+++ b/test/unit/domain/batch/tracker.test.js
@@ -24,8 +24,8 @@ Test('BatchTracker', trackerTest => {
 
   trackerTest.test('create should', createTest => {
     createTest.test('create new batch tracker and setup', test => {
-      let settings = { batchSize: 50, batchTimeInterval: 60000 }
-      let tracker = BatchTracker.create(settings)
+      const settings = { batchSize: 50, batchTimeInterval: 60000 }
+      const tracker = BatchTracker.create(settings)
 
       test.equal(tracker._batchSize, settings.batchSize)
       test.equal(tracker._batchTimeInterval, settings.batchTimeInterval)
@@ -35,7 +35,7 @@ Test('BatchTracker', trackerTest => {
     })
 
     createTest.test('use default settings', test => {
-      let tracker = BatchTracker.create()
+      const tracker = BatchTracker.create()
 
       test.equal(tracker._batchSize, 64)
       test.equal(tracker._batchTimeInterval, 300000)
@@ -47,9 +47,9 @@ Test('BatchTracker', trackerTest => {
 
   trackerTest.test('eventCreated should', eventCreatedTest => {
     eventCreatedTest.test('add event to list', test => {
-      let tracker = BatchTracker.create()
+      const tracker = BatchTracker.create()
 
-      let eventId = Uuid()
+      const eventId = Uuid()
 
       tracker.eventCreated(eventId)
 
@@ -59,12 +59,12 @@ Test('BatchTracker', trackerTest => {
     })
 
     eventCreatedTest.test('emit batchReady event if unbatched length equal to batch size', test => {
-      let eventId1 = Uuid()
-      let eventId2 = Uuid()
-      let batchSize = 2
-      let batchReadySpy = sandbox.spy()
+      const eventId1 = Uuid()
+      const eventId2 = Uuid()
+      const batchSize = 2
+      const batchReadySpy = sandbox.spy()
 
-      let tracker = BatchTracker.create({ batchSize })
+      const tracker = BatchTracker.create({ batchSize })
       tracker.on('batchReady', batchReadySpy)
 
       tracker.eventCreated(eventId1)
@@ -78,13 +78,13 @@ Test('BatchTracker', trackerTest => {
     })
 
     eventCreatedTest.test('emit batchReady event if unbatched length greater than batch size', test => {
-      let eventId1 = Uuid()
-      let eventId2 = Uuid()
-      let eventId3 = Uuid()
-      let batchSize = 2
-      let batchReadySpy = sandbox.spy()
+      const eventId1 = Uuid()
+      const eventId2 = Uuid()
+      const eventId3 = Uuid()
+      const batchSize = 2
+      const batchReadySpy = sandbox.spy()
 
-      let tracker = BatchTracker.create({ batchSize })
+      const tracker = BatchTracker.create({ batchSize })
       tracker._unbatchedEvents.push(eventId1)
       tracker._unbatchedEvents.push(eventId2)
       tracker.on('batchReady', batchReadySpy)
@@ -97,11 +97,11 @@ Test('BatchTracker', trackerTest => {
     })
 
     eventCreatedTest.test('not emit batchReady event if unbatched length less than batch size', test => {
-      let eventId1 = Uuid()
-      let batchSize = 2
-      let batchReadySpy = sandbox.spy()
+      const eventId1 = Uuid()
+      const batchSize = 2
+      const batchReadySpy = sandbox.spy()
 
-      let tracker = BatchTracker.create({ batchSize })
+      const tracker = BatchTracker.create({ batchSize })
       tracker.on('batchReady', batchReadySpy)
 
       tracker.eventCreated(eventId1)
@@ -112,15 +112,15 @@ Test('BatchTracker', trackerTest => {
     })
 
     eventCreatedTest.test('reset batch timer', test => {
-      let eventId1 = Uuid()
-      let eventId2 = Uuid()
-      let batchSize = 2
-      let batchReadySpy = sandbox.spy()
+      const eventId1 = Uuid()
+      const eventId2 = Uuid()
+      const batchSize = 2
+      const batchReadySpy = sandbox.spy()
 
-      let tracker = BatchTracker.create({ batchSize })
+      const tracker = BatchTracker.create({ batchSize })
       tracker.on('batchReady', batchReadySpy)
 
-      let origBatchTimer = tracker._batchTimer
+      const origBatchTimer = tracker._batchTimer
 
       tracker.eventCreated(eventId1)
       tracker.eventCreated(eventId2)
@@ -136,18 +136,18 @@ Test('BatchTracker', trackerTest => {
 
   trackerTest.test('batch timer elapsed should', batchTimerTest => {
     batchTimerTest.test('emit batchReady event and reset timer', test => {
-      let eventId1 = Uuid()
-      let eventId2 = Uuid()
-      let batchSize = 5
-      let batchTimeInterval = 5000
-      let batchReadySpy = sandbox.spy()
+      const eventId1 = Uuid()
+      const eventId2 = Uuid()
+      const batchSize = 5
+      const batchTimeInterval = 5000
+      const batchReadySpy = sandbox.spy()
 
-      let tracker = BatchTracker.create({ batchSize, batchTimeInterval })
+      const tracker = BatchTracker.create({ batchSize, batchTimeInterval })
       tracker._unbatchedEvents.push(eventId1)
       tracker._unbatchedEvents.push(eventId2)
       tracker.on('batchReady', batchReadySpy)
 
-      let origBatchTimer = tracker._batchTimer
+      const origBatchTimer = tracker._batchTimer
 
       clock.tick(batchTimeInterval)
 

--- a/test/unit/domain/event/index.test.js
+++ b/test/unit/domain/event/index.test.js
@@ -31,21 +31,21 @@ Test('Events service', serviceTest => {
 
   serviceTest.test('create should', createTest => {
     createTest.test('create signature and persist to model', test => {
-      let sidecarId = Uuid()
-      let sequence = 1
-      let message = 'test message'
-      let signingKey = 'DFDE22A3276FC520A24FBE5534EDADFE080D78375C4530E038EFCF6CA699228A'
-      let now = Moment()
+      const sidecarId = Uuid()
+      const sequence = 1
+      const message = 'test message'
+      const signingKey = 'DFDE22A3276FC520A24FBE5534EDADFE080D78375C4530E038EFCF6CA699228A'
+      const now = Moment()
 
-      let savedEvent = {}
+      const savedEvent = {}
       Model.create.returns(P.resolve(savedEvent))
 
-      let signature = 'signature'
+      const signature = 'signature'
       SymmetricCrypto.sign.returns(signature)
 
       Moment.utc.returns(now)
 
-      let compactJSON = `{"keyId":"${sidecarId}","sequence":${sequence},"message":"${message}","timestamp":"${now.toISOString()}"}`
+      const compactJSON = `{"keyId":"${sidecarId}","sequence":${sequence},"message":"${message}","timestamp":"${now.toISOString()}"}`
 
       Service.create(sidecarId, sequence, message, signingKey)
         .then(s => {
@@ -67,8 +67,8 @@ Test('Events service', serviceTest => {
 
   serviceTest.test('getUnbatchedEventsByIds should', getUnbatchedEventsByIdsTest => {
     getUnbatchedEventsByIdsTest.test('get unbatched events from model', test => {
-      let eventIds = [1, 2]
-      let events = [{ eventId: eventIds[0] }, { eventId: eventIds[1] }]
+      const eventIds = [1, 2]
+      const events = [{ eventId: eventIds[0] }, { eventId: eventIds[1] }]
 
       Model.getUnbatchedEvents.returns(P.resolve(events))
 
@@ -85,10 +85,10 @@ Test('Events service', serviceTest => {
 
   serviceTest.test('getEventCountInTimespan should', getEventCountTest => {
     getEventCountTest.test('get event count from model', test => {
-      let now = Moment()
-      let start = Moment(now).subtract(5, 'minutes')
-      let sidecarId = 'sidecar-id'
-      let count = 6
+      const now = Moment()
+      const start = Moment(now).subtract(5, 'minutes')
+      const sidecarId = 'sidecar-id'
+      const count = 6
 
       Model.getEventCount.returns(P.resolve(count))
 
@@ -104,10 +104,10 @@ Test('Events service', serviceTest => {
     })
 
     getEventCountTest.test('convert dates to strings before calling model', test => {
-      let now = Moment()
-      let start = Moment(now).subtract(5, 'minutes')
-      let sidecarId = 'sidecar-id'
-      let count = 6
+      const now = Moment()
+      const start = Moment(now).subtract(5, 'minutes')
+      const sidecarId = 'sidecar-id'
+      const count = 6
 
       Model.getEventCount.returns(P.resolve(count))
 
@@ -127,10 +127,10 @@ Test('Events service', serviceTest => {
 
   serviceTest.test('assignEventsToBatch should', assignEventsTest => {
     assignEventsTest.test('update events with batch id', test => {
-      let batchId = 1
-      let batch = { batchId }
-      let events = [{ eventId: 1 }, { eventId: 2 }]
-      let updatedEvents = [{ eventId: 1, batchId }, { eventId: 2, batchId }]
+      const batchId = 1
+      const batch = { batchId }
+      const events = [{ eventId: 1 }, { eventId: 2 }]
+      const updatedEvents = [{ eventId: 1, batchId }, { eventId: 2, batchId }]
 
       Model.updateEvents.returns(P.resolve(updatedEvents))
 

--- a/test/unit/domain/event/model.test.js
+++ b/test/unit/domain/event/model.test.js
@@ -31,8 +31,8 @@ Test('Events model', modelTest => {
 
   modelTest.test('create should', createTest => {
     createTest.test('save payload and return new event', test => {
-      let payload = { eventId: 'event-id', sidecarId: 'sidecar-id', sequence: 1, message: 'test message', signature: 'test' }
-      let insertedEvent = { eventId: payload.eventId }
+      const payload = { eventId: 'event-id', sidecarId: 'sidecar-id', sequence: 1, message: 'test message', signature: 'test' }
+      const insertedEvent = { eventId: payload.eventId }
 
       Db.events.insert.returns(P.resolve(insertedEvent))
 
@@ -49,8 +49,8 @@ Test('Events model', modelTest => {
 
   modelTest.test('getUnbatchedEvents should', getUnbatchedEventsTest => {
     getUnbatchedEventsTest.test('find unbatched events for array of ids and order by sequence', test => {
-      let eventIds = [1, 2]
-      let events = [{ eventId: eventIds[0] }, { eventId: eventIds[1] }]
+      const eventIds = [1, 2]
+      const events = [{ eventId: eventIds[0] }, { eventId: eventIds[1] }]
 
       Db.events.find.returns(P.resolve(events))
 
@@ -67,8 +67,8 @@ Test('Events model', modelTest => {
 
   modelTest.test('getEventCount should', getEventCountTest => {
     getEventCountTest.test('get count of events for a sidecar id', test => {
-      let count = 5
-      let sidecarId = 'sidecar-id'
+      const count = 5
+      const sidecarId = 'sidecar-id'
 
       Db.events.count.returns(P.resolve(count))
 
@@ -81,13 +81,13 @@ Test('Events model', modelTest => {
     })
 
     getEventCountTest.test('get count of sidecar events for a timespan', test => {
-      let count = 5
-      let now = Moment.utc()
-      let start = Moment.utc(now).subtract(5, 'minutes')
-      let sidecarId = 'sidecar-id'
+      const count = 5
+      const now = Moment.utc()
+      const start = Moment.utc(now).subtract(5, 'minutes')
+      const sidecarId = 'sidecar-id'
 
-      let startTime = start.toISOString()
-      let endTime = now.toISOString()
+      const startTime = start.toISOString()
+      const endTime = now.toISOString()
 
       Db.events.count.returns(P.resolve(count))
 
@@ -104,10 +104,10 @@ Test('Events model', modelTest => {
 
   modelTest.test('updateEvents should', updateEventsTest => {
     updateEventsTest.test('update multiple events', test => {
-      let batchId = 1
-      let eventIds = [1, 2]
-      let fields = { batchId }
-      let updatedEvents = [{ eventId: eventIds[0], batchId }, { eventId: eventIds[1], batchId }]
+      const batchId = 1
+      const eventIds = [1, 2]
+      const fields = { batchId }
+      const updatedEvents = [{ eventId: eventIds[0], batchId }, { eventId: eventIds[1], batchId }]
 
       Db.events.update.returns(P.resolve(updatedEvents))
 

--- a/test/unit/domain/sidecar/index.test.js
+++ b/test/unit/domain/sidecar/index.test.js
@@ -24,12 +24,12 @@ Test('Sidecars service', serviceTest => {
 
   serviceTest.test('create should', createTest => {
     createTest.test('persist sidecar to model', test => {
-      let sidecarId = 'sidecar-id'
-      let serviceName = 'test'
-      let version = '0.0.2'
-      let created = Moment()
+      const sidecarId = 'sidecar-id'
+      const serviceName = 'test'
+      const version = '0.0.2'
+      const created = Moment()
 
-      let savedSidecar = {}
+      const savedSidecar = {}
       Model.create.returns(P.resolve(savedSidecar))
 
       Service.create(sidecarId, serviceName, version, created)

--- a/test/unit/domain/sidecar/model.test.js
+++ b/test/unit/domain/sidecar/model.test.js
@@ -27,8 +27,8 @@ Test('Sidecars model', modelTest => {
 
   modelTest.test('create should', createTest => {
     createTest.test('save payload and return new sidecar', test => {
-      let payload = { sidecarId: 'sidecar-id', serviceName: 'test service', version: '0.0.1' }
-      let insertedSidecar = { sidecarId: 'id' }
+      const payload = { sidecarId: 'sidecar-id', serviceName: 'test service', version: '0.0.1' }
+      const insertedSidecar = { sidecarId: 'id' }
 
       Db.sidecars.insert.returns(P.resolve(insertedSidecar))
 

--- a/test/unit/fixtures.js
+++ b/test/unit/fixtures.js
@@ -1,21 +1,21 @@
 'use strict'
 
 function writeMessageToBuffer (msg) {
-  let message = Buffer.isBuffer(msg) ? msg : Buffer.from(msg)
-  let length = message.length
+  const message = Buffer.isBuffer(msg) ? msg : Buffer.from(msg)
+  const length = message.length
 
-  let buffer = Buffer.alloc(length)
+  const buffer = Buffer.alloc(length)
   message.copy(buffer, 0, 0, length)
   return buffer
 }
 
 function writeMessageToBufferWithLength (msg) {
-  let prefixSize = 4
+  const prefixSize = 4
 
-  let message = Buffer.isBuffer(msg) ? msg : Buffer.from(msg)
-  let length = message.length
+  const message = Buffer.isBuffer(msg) ? msg : Buffer.from(msg)
+  const length = message.length
 
-  let buffer = Buffer.alloc(prefixSize + length)
+  const buffer = Buffer.alloc(prefixSize + length)
   buffer.writeUInt32BE(length, 0)
   message.copy(buffer, prefixSize, 0, length)
   return buffer

--- a/test/unit/health-check.test.js
+++ b/test/unit/health-check.test.js
@@ -25,15 +25,15 @@ Test('HealthCheck', healthCheckTest => {
 
   healthCheckTest.test('ping should', pingTest => {
     pingTest.test('perform a ping health check and return results', test => {
-      let eventCount = 50
+      const eventCount = 50
 
-      let now = Moment()
+      const now = Moment()
       Moment.utc.returns(now)
-      let startTime = Moment(now).subtract(1, 'hour')
+      const startTime = Moment(now).subtract(1, 'hour')
 
       EventService.getEventCountInTimespan.returns(P.resolve(eventCount))
 
-      let sidecar = { id: 'sidecar-id', version: '0.0.1', startTime }
+      const sidecar = { id: 'sidecar-id', version: '0.0.1', startTime }
 
       HealthCheck.ping(sidecar)
         .then(hc => {

--- a/test/unit/health.test.js
+++ b/test/unit/health.test.js
@@ -31,7 +31,7 @@ Test('Health', serverTest => {
       Server: sandbox.stub().returns(serverStub)
     }
     Setup = Proxyquire('../../src/health', {
-      'hapi': HapiStub
+      hapi: HapiStub
     })
     test.end()
   })

--- a/test/unit/keys.test.js
+++ b/test/unit/keys.test.js
@@ -20,7 +20,7 @@ Test('Keys', keysTest => {
 
   keysTest.test('create should', createTest => {
     createTest.test('create new key store and set properties', test => {
-      let keyStore = Keys.create()
+      const keyStore = Keys.create()
 
       test.equal(keyStore._rowKey, null)
       test.equal(keyStore._batchKey, null)
@@ -32,9 +32,9 @@ Test('Keys', keysTest => {
 
   keysTest.test('store should', storeTest => {
     storeTest.test('store batch key and row key', test => {
-      let keyStore = Keys.create()
+      const keyStore = Keys.create()
 
-      let keys = { rowKey: 'row-key', batchKey: 'batch-key' }
+      const keys = { rowKey: 'row-key', batchKey: 'batch-key' }
 
       keyStore.store(keys)
       test.equal(keyStore._rowKey, keys.rowKey)
@@ -47,9 +47,9 @@ Test('Keys', keysTest => {
 
   keysTest.test('getRowKey should', rowKeyTest => {
     rowKeyTest.test('return stored row key', test => {
-      let keyStore = Keys.create()
+      const keyStore = Keys.create()
 
-      let keys = { rowKey: 'row-key', batchKey: 'batch-key' }
+      const keys = { rowKey: 'row-key', batchKey: 'batch-key' }
 
       keyStore.store(keys)
       test.equal(keyStore.getRowKey(), keys.rowKey)
@@ -57,7 +57,7 @@ Test('Keys', keysTest => {
     })
 
     rowKeyTest.test('return null if no row key stored', test => {
-      let keyStore = Keys.create()
+      const keyStore = Keys.create()
       test.equal(keyStore.getRowKey(), null)
       test.end()
     })
@@ -67,9 +67,9 @@ Test('Keys', keysTest => {
 
   keysTest.test('getBatchKey should', batchKeyTest => {
     batchKeyTest.test('return stored batch key', test => {
-      let keyStore = Keys.create()
+      const keyStore = Keys.create()
 
-      let keys = { rowKey: 'row-key', batchKey: 'batch-key' }
+      const keys = { rowKey: 'row-key', batchKey: 'batch-key' }
 
       keyStore.store(keys)
       test.equal(keyStore.getBatchKey(), keys.batchKey)
@@ -77,7 +77,7 @@ Test('Keys', keysTest => {
     })
 
     batchKeyTest.test('return null if no batch key stored', test => {
-      let keyStore = Keys.create()
+      const keyStore = Keys.create()
       test.equal(keyStore.getBatchKey(), null)
       test.end()
     })

--- a/test/unit/kms/index.test.js
+++ b/test/unit/kms/index.test.js
@@ -28,7 +28,7 @@ Test('KmsConnection', kmsConnTest => {
     sandbox.stub(AsymmetricCrypto, 'sign')
 
     uuidStub = sandbox.stub()
-    KmsConnection = Proxyquire(`${src}/kms`, { 'uuid4': uuidStub })
+    KmsConnection = Proxyquire(`${src}/kms`, { uuid4: uuidStub })
 
     t.end()
   })
@@ -40,7 +40,7 @@ Test('KmsConnection', kmsConnTest => {
 
   kmsConnTest.test('create should', createTest => {
     createTest.test('create new connection and set properties', test => {
-      let settings = { url: 'ws://test.com', pingInterval: 5000, requestTimeout: 15000, connectTimeout: 9000, reconnectInterval: 2000 }
+      const settings = { url: 'ws://test.com', pingInterval: 5000, requestTimeout: 15000, connectTimeout: 9000, reconnectInterval: 2000 }
       KmsConnection.create(settings)
 
       test.ok(WebSocket.create.calledWith(sandbox.match({
@@ -76,15 +76,15 @@ Test('KmsConnection', kmsConnTest => {
 
   kmsConnTest.test('connect should', connectTest => {
     connectTest.test('connect to websocket and resolve when open', test => {
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.connect = sandbox.stub()
       wsEmitter.isConnected = sandbox.stub().returns(false)
       WebSocket.create.returns(wsEmitter)
 
-      let settings = { url: 'ws://test.com', pingInterval: 5000 }
-      let kmsConnection = KmsConnection.create(settings)
+      const settings = { url: 'ws://test.com', pingInterval: 5000 }
+      const kmsConnection = KmsConnection.create(settings)
 
-      let connectPromise = kmsConnection.connect()
+      const connectPromise = kmsConnection.connect()
       test.ok(wsEmitter.connect.calledOnce)
       test.ok(wsEmitter.listenerCount('open'), 1)
       test.ok(wsEmitter.listenerCount('error'), 1)
@@ -104,21 +104,21 @@ Test('KmsConnection', kmsConnTest => {
     })
 
     connectTest.test('reject if error event emitted', test => {
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.connect = sandbox.stub()
       wsEmitter.isConnected = sandbox.stub().returns(false)
       WebSocket.create.returns(wsEmitter)
 
-      let settings = { url: 'ws://test.com' }
-      let kmsConnection = KmsConnection.create(settings)
+      const settings = { url: 'ws://test.com' }
+      const kmsConnection = KmsConnection.create(settings)
 
-      let connectPromise = kmsConnection.connect()
+      const connectPromise = kmsConnection.connect()
       test.ok(wsEmitter.connect.calledOnce)
       test.ok(wsEmitter.listenerCount('open'), 1)
       test.ok(wsEmitter.listenerCount('error'), 1)
       test.equal(wsEmitter.listeners('error')[0].name.indexOf('_onWebSocketError'), -1)
 
-      let error = new Error('Error connecting to websocket')
+      const error = new Error('Error connecting to websocket')
       wsEmitter.emit('error', error)
 
       connectPromise
@@ -137,12 +137,12 @@ Test('KmsConnection', kmsConnTest => {
     })
 
     connectTest.test('return immediately if already connected', test => {
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.connect = sandbox.stub()
       wsEmitter.isConnected = sandbox.stub().returns(true)
       WebSocket.create.returns(wsEmitter)
 
-      let kmsConnection = KmsConnection.create()
+      const kmsConnection = KmsConnection.create()
 
       kmsConnection.connect()
         .then(() => {
@@ -156,13 +156,13 @@ Test('KmsConnection', kmsConnTest => {
 
   kmsConnTest.test('close should', closeTest => {
     closeTest.test('call close method on websocket connection', test => {
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.connect = sandbox.stub()
       wsEmitter.isConnected = sandbox.stub().returns(true)
       wsEmitter.close = sandbox.stub()
       WebSocket.create.returns(wsEmitter)
 
-      let kmsConnection = KmsConnection.create()
+      const kmsConnection = KmsConnection.create()
 
       kmsConnection.connect()
         .then(() => {
@@ -178,11 +178,11 @@ Test('KmsConnection', kmsConnTest => {
 
   kmsConnTest.test('register should', registerTest => {
     registerTest.test('reject if not connected', test => {
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.isConnected = sandbox.stub().returns(false)
       WebSocket.create.returns(wsEmitter)
 
-      let conn = KmsConnection.create()
+      const conn = KmsConnection.create()
 
       conn.register('id')
         .then(() => {
@@ -196,29 +196,29 @@ Test('KmsConnection', kmsConnTest => {
     })
 
     registerTest.test('register with KMS and perform challenge', test => {
-      let requestStartStub = sandbox.stub()
+      const requestStartStub = sandbox.stub()
       Requests.create.returns({ start: requestStartStub })
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.send = sandbox.stub()
       wsEmitter.isConnected = sandbox.stub().returns(true)
       WebSocket.create.returns(wsEmitter)
 
-      let sidecarId = 'sidecar1'
-      let serviceName = 'TestSidecar'
+      const sidecarId = 'sidecar1'
+      const serviceName = 'TestSidecar'
 
-      let registerMessageId = `register-${sidecarId}`
-      let registerRequest = { jsonrpc: '2.0', id: registerMessageId, method: 'register', params: { id: sidecarId, serviceName } }
-      let registerResponse = { jsonrpc: '2.0', id: registerMessageId, result: { id: sidecarId, batchKey: 'batch-key', rowKey: 'row-key', challenge: 'challenge' } }
+      const registerMessageId = `register-${sidecarId}`
+      const registerRequest = { jsonrpc: '2.0', id: registerMessageId, method: 'register', params: { id: sidecarId, serviceName } }
+      const registerResponse = { jsonrpc: '2.0', id: registerMessageId, result: { id: sidecarId, batchKey: 'batch-key', rowKey: 'row-key', challenge: 'challenge' } }
 
       const rowSignature = 'row-signature'
       const batchSignature = 'batch-signature'
       SymmetricCrypto.sign.returns(rowSignature)
       AsymmetricCrypto.sign.returns(batchSignature)
 
-      let challengeMessageId = `challenge-${sidecarId}`
-      let challengeRequest = { jsonrpc: '2.0', id: challengeMessageId, method: 'challenge', params: { rowSignature, batchSignature } }
-      let challengeResponse = { jsonrpc: '2.0', id: challengeMessageId, result: { status: 'ok' } }
+      const challengeMessageId = `challenge-${sidecarId}`
+      const challengeRequest = { jsonrpc: '2.0', id: challengeMessageId, method: 'challenge', params: { rowSignature, batchSignature } }
+      const challengeResponse = { jsonrpc: '2.0', id: challengeMessageId, result: { status: 'ok' } }
 
       requestStartStub.onFirstCall().callsArgWith(0, registerMessageId)
       requestStartStub.onFirstCall().returns(P.resolve(registerResponse))
@@ -226,9 +226,9 @@ Test('KmsConnection', kmsConnTest => {
       requestStartStub.onSecondCall().callsArgWith(0, challengeMessageId)
       requestStartStub.onSecondCall().returns(P.resolve(challengeResponse))
 
-      let kmsConnection = KmsConnection.create()
+      const kmsConnection = KmsConnection.create()
 
-      let registerPromise = kmsConnection.register(sidecarId, serviceName)
+      const registerPromise = kmsConnection.register(sidecarId, serviceName)
       registerPromise
         .then(keys => {
           test.deepEqual(JSON.parse(wsEmitter.send.firstCall.args), registerRequest)
@@ -244,26 +244,26 @@ Test('KmsConnection', kmsConnTest => {
     })
 
     registerTest.test('throw error if KMS sends error during registration', test => {
-      let requestStartStub = sandbox.stub()
+      const requestStartStub = sandbox.stub()
       Requests.create.returns({ start: requestStartStub })
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.send = sandbox.stub()
       wsEmitter.connect = sandbox.stub()
       wsEmitter.isConnected = sandbox.stub().returns(true)
       WebSocket.create.returns(wsEmitter)
 
-      let sidecarId = 'sidecar1'
+      const sidecarId = 'sidecar1'
 
-      let registerMessageId = `register-${sidecarId}`
-      let registerResponse = { jsonrpc: '2.0', id: registerMessageId, error: { id: 101, message: 'bad stuff' } }
+      const registerMessageId = `register-${sidecarId}`
+      const registerResponse = { jsonrpc: '2.0', id: registerMessageId, error: { id: 101, message: 'bad stuff' } }
 
       requestStartStub.onFirstCall().callsArgWith(0, registerMessageId)
       requestStartStub.onFirstCall().returns(P.resolve(registerResponse))
 
-      let kmsConnection = KmsConnection.create()
+      const kmsConnection = KmsConnection.create()
 
-      let registerPromise = kmsConnection.register(sidecarId)
+      const registerPromise = kmsConnection.register(sidecarId)
       registerPromise
         .then(() => {
           test.fail('Should have thrown error')
@@ -278,22 +278,22 @@ Test('KmsConnection', kmsConnTest => {
     })
 
     registerTest.test('throw error if KMS sends error during challenge', test => {
-      let requestStartStub = sandbox.stub()
+      const requestStartStub = sandbox.stub()
       Requests.create.returns({ start: requestStartStub })
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.send = sandbox.stub()
       wsEmitter.connect = sandbox.stub()
       wsEmitter.isConnected = sandbox.stub().returns(true)
       WebSocket.create.returns(wsEmitter)
 
-      let sidecarId = 'sidecar1'
+      const sidecarId = 'sidecar1'
 
-      let registerMessageId = `register-${sidecarId}`
-      let registerResponse = { jsonrpc: '2.0', id: registerMessageId, result: { id: sidecarId, batchKey: 'batch-key', rowKey: 'row-key', challenge: 'challenge' } }
+      const registerMessageId = `register-${sidecarId}`
+      const registerResponse = { jsonrpc: '2.0', id: registerMessageId, result: { id: sidecarId, batchKey: 'batch-key', rowKey: 'row-key', challenge: 'challenge' } }
 
-      let challengeMessageId = `challenge-${sidecarId}`
-      let challengeResponse = { jsonrpc: '2.0', id: challengeMessageId, error: { id: 105, message: 'bad challenge' } }
+      const challengeMessageId = `challenge-${sidecarId}`
+      const challengeResponse = { jsonrpc: '2.0', id: challengeMessageId, error: { id: 105, message: 'bad challenge' } }
 
       requestStartStub.onFirstCall().callsArgWith(0, registerMessageId)
       requestStartStub.onFirstCall().returns(P.resolve(registerResponse))
@@ -301,9 +301,9 @@ Test('KmsConnection', kmsConnTest => {
       requestStartStub.onSecondCall().callsArgWith(0, challengeMessageId)
       requestStartStub.onSecondCall().returns(P.resolve(challengeResponse))
 
-      let kmsConnection = KmsConnection.create()
+      const kmsConnection = KmsConnection.create()
 
-      let registerPromise = kmsConnection.register(sidecarId)
+      const registerPromise = kmsConnection.register(sidecarId)
       registerPromise
         .then(() => {
           test.fail('Should have thrown error')
@@ -317,22 +317,22 @@ Test('KmsConnection', kmsConnTest => {
     })
 
     registerTest.test('throw error if KMS returns invalid status during challenge', test => {
-      let requestStartStub = sandbox.stub()
+      const requestStartStub = sandbox.stub()
       Requests.create.returns({ start: requestStartStub })
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.send = sandbox.stub()
       wsEmitter.connect = sandbox.stub()
       wsEmitter.isConnected = sandbox.stub().returns(true)
       WebSocket.create.returns(wsEmitter)
 
-      let sidecarId = 'sidecar1'
+      const sidecarId = 'sidecar1'
 
-      let registerMessageId = `register-${sidecarId}`
-      let registerResponse = { jsonrpc: '2.0', id: registerMessageId, result: { id: sidecarId, batchKey: 'batch-key', rowKey: 'row-key', challenge: 'challenge' } }
+      const registerMessageId = `register-${sidecarId}`
+      const registerResponse = { jsonrpc: '2.0', id: registerMessageId, result: { id: sidecarId, batchKey: 'batch-key', rowKey: 'row-key', challenge: 'challenge' } }
 
-      let challengeMessageId = `challenge-${sidecarId}`
-      let challengeResponse = { jsonrpc: '2.0', id: challengeMessageId, result: { status: 'nope' } }
+      const challengeMessageId = `challenge-${sidecarId}`
+      const challengeResponse = { jsonrpc: '2.0', id: challengeMessageId, result: { status: 'nope' } }
 
       requestStartStub.onFirstCall().callsArgWith(0, registerMessageId)
       requestStartStub.onFirstCall().returns(P.resolve(registerResponse))
@@ -340,9 +340,9 @@ Test('KmsConnection', kmsConnTest => {
       requestStartStub.onSecondCall().callsArgWith(0, challengeMessageId)
       requestStartStub.onSecondCall().returns(P.resolve(challengeResponse))
 
-      let kmsConnection = KmsConnection.create()
+      const kmsConnection = KmsConnection.create()
 
-      let registerPromise = kmsConnection.register(sidecarId)
+      const registerPromise = kmsConnection.register(sidecarId)
       registerPromise
         .then(() => {
           test.fail('Should have thrown error')
@@ -359,14 +359,14 @@ Test('KmsConnection', kmsConnTest => {
 
   kmsConnTest.test('respondToHealthCheck should', respondHcTest => {
     respondHcTest.test('send healthcheck response from request', test => {
-      let id = 'request-id'
-      let request = { id }
-      let healthCheck = {}
-      let jsonRpcResponse = { jsonrpc: '2.0', id, result: healthCheck }
+      const id = 'request-id'
+      const request = { id }
+      const healthCheck = {}
+      const jsonRpcResponse = { jsonrpc: '2.0', id, result: healthCheck }
 
-      let ws = { send: sandbox.stub() }
+      const ws = { send: sandbox.stub() }
 
-      let conn = KmsConnection.create()
+      const conn = KmsConnection.create()
       conn._ws = ws
 
       conn.respondToHealthCheck(request, healthCheck)
@@ -380,23 +380,23 @@ Test('KmsConnection', kmsConnTest => {
 
   kmsConnTest.test('respondToInquiry should', respondInquiryTest => {
     respondInquiryTest.test('send inquiry response to KMS for each found batch', test => {
-      let method = 'inquiry-response'
-      let inquiryId = 'inquiry-id'
-      let requestId = 'response-id'
-      let requestId2 = 'response-id2'
+      const method = 'inquiry-response'
+      const inquiryId = 'inquiry-id'
+      const requestId = 'response-id'
+      const requestId2 = 'response-id2'
 
       uuidStub.onFirstCall().returns(requestId)
       uuidStub.onSecondCall().returns(requestId2)
 
-      let request = { inquiryId }
-      let results = [{ batchId: 'batch-id', data: 'this is data' }, { batchId: 'batch-id2', data: 'more data' }]
+      const request = { inquiryId }
+      const results = [{ batchId: 'batch-id', data: 'this is data' }, { batchId: 'batch-id2', data: 'more data' }]
 
-      let jsonRpcRequest = { jsonrpc: '2.0', id: requestId, method, params: { inquiry: inquiryId, id: results[0].batchId, body: results[0].data, total: 2, item: 1 } }
-      let jsonRpcRequest2 = { jsonrpc: '2.0', id: requestId2, method, params: { inquiry: inquiryId, id: results[1].batchId, body: results[1].data, total: 2, item: 2 } }
+      const jsonRpcRequest = { jsonrpc: '2.0', id: requestId, method, params: { inquiry: inquiryId, id: results[0].batchId, body: results[0].data, total: 2, item: 1 } }
+      const jsonRpcRequest2 = { jsonrpc: '2.0', id: requestId2, method, params: { inquiry: inquiryId, id: results[1].batchId, body: results[1].data, total: 2, item: 2 } }
 
-      let ws = { send: sandbox.stub() }
+      const ws = { send: sandbox.stub() }
 
-      let conn = KmsConnection.create()
+      const conn = KmsConnection.create()
       conn._ws = ws
 
       conn.respondToInquiry(request, results)
@@ -408,20 +408,20 @@ Test('KmsConnection', kmsConnTest => {
     })
 
     respondInquiryTest.test('send special inquiry response to KMS if no results found', test => {
-      let method = 'inquiry-response'
-      let inquiryId = 'inquiry-id'
-      let requestId = 'response-id'
+      const method = 'inquiry-response'
+      const inquiryId = 'inquiry-id'
+      const requestId = 'response-id'
 
       uuidStub.onFirstCall().returns(requestId)
 
-      let request = { inquiryId }
-      let results = []
+      const request = { inquiryId }
+      const results = []
 
-      let jsonRpcRequest = { jsonrpc: '2.0', id: requestId, method, params: { inquiry: inquiryId, total: 0, item: 0 } }
+      const jsonRpcRequest = { jsonrpc: '2.0', id: requestId, method, params: { inquiry: inquiryId, total: 0, item: 0 } }
 
-      let ws = { send: sandbox.stub() }
+      const ws = { send: sandbox.stub() }
 
-      let conn = KmsConnection.create()
+      const conn = KmsConnection.create()
       conn._ws = ws
 
       conn.respondToInquiry(request, results)
@@ -436,26 +436,26 @@ Test('KmsConnection', kmsConnTest => {
 
   kmsConnTest.test('sendBatch should', sendBatchTest => {
     sendBatchTest.test('send batch and return pending promise', test => {
-      let requestId = 'request'
+      const requestId = 'request'
 
-      let method = 'batch'
-      let batch = { batchId: 'batch-id', signature: 'sig' }
-      let jsonRpcRequest = { jsonrpc: '2.0', id: requestId, method, params: { id: 'batch-id', signature: 'sig' } }
+      const method = 'batch'
+      const batch = { batchId: 'batch-id', signature: 'sig' }
+      const jsonRpcRequest = { jsonrpc: '2.0', id: requestId, method, params: { id: 'batch-id', signature: 'sig' } }
 
-      let ws = { send: sandbox.stub() }
+      const ws = { send: sandbox.stub() }
 
-      let requestStartStub = sandbox.stub()
+      const requestStartStub = sandbox.stub()
       Requests.create.returns({ start: requestStartStub })
 
-      let conn = KmsConnection.create()
+      const conn = KmsConnection.create()
       conn._ws = ws
 
-      let result = { test: 'test' }
+      const result = { test: 'test' }
 
       requestStartStub.onFirstCall().callsArgWith(0, requestId)
       requestStartStub.onFirstCall().returns(P.resolve({ result }))
 
-      let requestPromise = conn.sendBatch(batch)
+      const requestPromise = conn.sendBatch(batch)
       requestPromise
         .then(r => {
           test.equal(r, result)
@@ -471,26 +471,26 @@ Test('KmsConnection', kmsConnTest => {
 
   kmsConnTest.test('request should', requestTest => {
     requestTest.test('send JSONRPC request and return pending promise', test => {
-      let requestId = 'request'
+      const requestId = 'request'
 
-      let method = 'test'
-      let params = { key: 'val' }
-      let jsonRpcRequest = { jsonrpc: '2.0', id: requestId, method, params }
+      const method = 'test'
+      const params = { key: 'val' }
+      const jsonRpcRequest = { jsonrpc: '2.0', id: requestId, method, params }
 
-      let ws = { send: sandbox.stub() }
+      const ws = { send: sandbox.stub() }
 
-      let requestStartStub = sandbox.stub()
+      const requestStartStub = sandbox.stub()
       Requests.create.returns({ start: requestStartStub })
 
-      let conn = KmsConnection.create()
+      const conn = KmsConnection.create()
       conn._ws = ws
 
-      let result = { test: 'test' }
+      const result = { test: 'test' }
 
       requestStartStub.onFirstCall().callsArgWith(0, requestId)
       requestStartStub.onFirstCall().returns(P.resolve({ result }))
 
-      let requestPromise = conn.request(method, params)
+      const requestPromise = conn.request(method, params)
       requestPromise
         .then(r => {
           test.equal(r, result)
@@ -506,13 +506,13 @@ Test('KmsConnection', kmsConnTest => {
 
   kmsConnTest.test('respond should', sendResponseTest => {
     sendResponseTest.test('send JSONRPC response', test => {
-      let id = 'id'
-      let result = { key: 'val' }
-      let jsonRpcResponse = { jsonrpc: '2.0', id, result }
+      const id = 'id'
+      const result = { key: 'val' }
+      const jsonRpcResponse = { jsonrpc: '2.0', id, result }
 
-      let ws = { send: sandbox.stub() }
+      const ws = { send: sandbox.stub() }
 
-      let conn = KmsConnection.create()
+      const conn = KmsConnection.create()
       conn._ws = ws
 
       conn.respond(id, result)
@@ -526,13 +526,13 @@ Test('KmsConnection', kmsConnTest => {
 
   kmsConnTest.test('respondError should', sendErrorResponseTest => {
     sendErrorResponseTest.test('send JSONRPC error response', test => {
-      let id = 'id'
-      let error = { id: 101, message: 'error happened' }
-      let jsonRpcErrorResponse = { jsonrpc: '2.0', id, error }
+      const id = 'id'
+      const error = { id: 101, message: 'error happened' }
+      const jsonRpcErrorResponse = { jsonrpc: '2.0', id, error }
 
-      let ws = { send: sandbox.stub() }
+      const ws = { send: sandbox.stub() }
 
-      let conn = KmsConnection.create()
+      const conn = KmsConnection.create()
       conn._ws = ws
 
       conn.respondError(id, error)
@@ -546,23 +546,23 @@ Test('KmsConnection', kmsConnTest => {
 
   kmsConnTest.test('receiving WebSocket close event should', closeEventTest => {
     closeEventTest.test('emit connectionClose event with canReconnect false if normal close', test => {
-      let connCloseSpy = sandbox.spy()
+      const connCloseSpy = sandbox.spy()
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.connect = sandbox.stub()
       wsEmitter.isConnected = sandbox.stub().returns(false)
       WebSocket.create.returns(wsEmitter)
 
-      let kmsConnection = KmsConnection.create()
+      const kmsConnection = KmsConnection.create()
       kmsConnection.on('connectionClose', connCloseSpy)
 
-      let connectPromise = kmsConnection.connect()
+      const connectPromise = kmsConnection.connect()
       wsEmitter.emit('open')
 
       connectPromise
         .then(() => {
-          let code = 1000
-          let reason = 'reason'
+          const code = 1000
+          const reason = 'reason'
           wsEmitter.emit('close', code, reason)
 
           test.ok(Logger.error.calledWith(`WebSocket connection closed: ${code} - ${reason}`))
@@ -572,23 +572,23 @@ Test('KmsConnection', kmsConnTest => {
     })
 
     closeEventTest.test('emit close event with canReconnect true if abnormal close', test => {
-      let connCloseSpy = sandbox.spy()
+      const connCloseSpy = sandbox.spy()
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.connect = sandbox.stub()
       wsEmitter.isConnected = sandbox.stub().returns(false)
       WebSocket.create.returns(wsEmitter)
 
-      let kmsConnection = KmsConnection.create()
+      const kmsConnection = KmsConnection.create()
       kmsConnection.on('connectionClose', connCloseSpy)
 
-      let connectPromise = kmsConnection.connect()
+      const connectPromise = kmsConnection.connect()
       wsEmitter.emit('open')
 
       connectPromise
         .then(() => {
-          let code = 1006
-          let reason = 'reason'
+          const code = 1006
+          const reason = 'reason'
           wsEmitter.emit('close', code, reason)
 
           test.ok(Logger.error.calledWith(`WebSocket connection closed: ${code} - ${reason}`))
@@ -602,22 +602,22 @@ Test('KmsConnection', kmsConnTest => {
 
   kmsConnTest.test('receiving WebSocket error event should', errorEventTest => {
     errorEventTest.test('emit close event with canReconnect true if error code ECONNREFUSED', test => {
-      let connCloseSpy = sandbox.spy()
+      const connCloseSpy = sandbox.spy()
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.connect = sandbox.stub()
       wsEmitter.isConnected = sandbox.stub().returns(false)
       WebSocket.create.returns(wsEmitter)
 
-      let kmsConnection = KmsConnection.create()
+      const kmsConnection = KmsConnection.create()
       kmsConnection.on('connectionClose', connCloseSpy)
 
-      let connectPromise = kmsConnection.connect()
+      const connectPromise = kmsConnection.connect()
       wsEmitter.emit('open')
 
       connectPromise
         .then(() => {
-          let err = new Error()
+          const err = new Error()
           err.code = 'ECONNREFUSED'
           wsEmitter.emit('error', err)
 
@@ -628,22 +628,22 @@ Test('KmsConnection', kmsConnTest => {
     })
 
     errorEventTest.test('emit close event with canReconnect false if no error code', test => {
-      let connCloseSpy = sandbox.spy()
+      const connCloseSpy = sandbox.spy()
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.connect = sandbox.stub()
       wsEmitter.isConnected = sandbox.stub().returns(false)
       WebSocket.create.returns(wsEmitter)
 
-      let kmsConnection = KmsConnection.create()
+      const kmsConnection = KmsConnection.create()
       kmsConnection.on('connectionClose', connCloseSpy)
 
-      let connectPromise = kmsConnection.connect()
+      const connectPromise = kmsConnection.connect()
       wsEmitter.emit('open')
 
       connectPromise
         .then(() => {
-          let err = new Error()
+          const err = new Error()
           wsEmitter.emit('error', err)
 
           test.ok(Logger.error.calledWith('Error on WebSocket connection', err))
@@ -657,19 +657,19 @@ Test('KmsConnection', kmsConnTest => {
 
   kmsConnTest.test('receiving WebSocket message event should', messageEventTest => {
     messageEventTest.test('log warning if not JSONRPC message', test => {
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.connect = sandbox.stub()
       wsEmitter.isConnected = sandbox.stub().returns(false)
       WebSocket.create.returns(wsEmitter)
 
-      let kmsConnection = KmsConnection.create()
+      const kmsConnection = KmsConnection.create()
 
-      let connectPromise = kmsConnection.connect()
+      const connectPromise = kmsConnection.connect()
       wsEmitter.emit('open')
 
       connectPromise
         .then(() => {
-          let data = JSON.stringify({ id: 'id' })
+          const data = JSON.stringify({ id: 'id' })
           wsEmitter.emit('message', data)
 
           test.ok(Logger.warn.calledWith(`Invalid message format received from KMS: ${data}`))
@@ -678,22 +678,22 @@ Test('KmsConnection', kmsConnTest => {
     })
 
     messageEventTest.test('emit healthCheck event for healthcheck request method', test => {
-      let healthCheckSpy = sandbox.spy()
+      const healthCheckSpy = sandbox.spy()
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.connect = sandbox.stub()
       wsEmitter.isConnected = sandbox.stub().returns(false)
       WebSocket.create.returns(wsEmitter)
 
-      let kmsConnection = KmsConnection.create()
+      const kmsConnection = KmsConnection.create()
       kmsConnection.on('healthCheck', healthCheckSpy)
 
-      let connectPromise = kmsConnection.connect()
+      const connectPromise = kmsConnection.connect()
       wsEmitter.emit('open')
 
       connectPromise
         .then(() => {
-          let healthCheck = { jsonrpc: '2.0', id: 'e1c609bd-e147-460b-ae61-98264bc935ad', method: 'healthcheck', params: { level: 'ping' } }
+          const healthCheck = { jsonrpc: '2.0', id: 'e1c609bd-e147-460b-ae61-98264bc935ad', method: 'healthcheck', params: { level: 'ping' } }
           wsEmitter.emit('message', JSON.stringify(healthCheck))
 
           test.ok(healthCheckSpy.calledWith(sandbox.match({
@@ -705,17 +705,17 @@ Test('KmsConnection', kmsConnTest => {
     })
 
     messageEventTest.test('emit inquiry event for inquiry request method', test => {
-      let inquirySpy = sandbox.spy()
+      const inquirySpy = sandbox.spy()
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.connect = sandbox.stub()
       wsEmitter.isConnected = sandbox.stub().returns(false)
       WebSocket.create.returns(wsEmitter)
 
-      let kmsConnection = KmsConnection.create()
+      const kmsConnection = KmsConnection.create()
       kmsConnection.on('inquiry', inquirySpy)
 
-      let connectPromise = kmsConnection.connect()
+      const connectPromise = kmsConnection.connect()
       wsEmitter.emit('open')
 
       const now = Moment()
@@ -726,7 +726,7 @@ Test('KmsConnection', kmsConnTest => {
 
       connectPromise
         .then(() => {
-          let inquiry = { jsonrpc: '2.0', id: 'e1c609bd-e147-460b-ae61-98264bc935ad', method: 'inquiry', params: { inquiry: '4e4f2a70-e0d6-42dc-9efb-6d23060ccd6f', startTime, endTime } }
+          const inquiry = { jsonrpc: '2.0', id: 'e1c609bd-e147-460b-ae61-98264bc935ad', method: 'inquiry', params: { inquiry: '4e4f2a70-e0d6-42dc-9efb-6d23060ccd6f', startTime, endTime } }
           wsEmitter.emit('message', JSON.stringify(inquiry))
 
           test.ok(inquirySpy.calledWith(sandbox.match({
@@ -740,19 +740,19 @@ Test('KmsConnection', kmsConnTest => {
     })
 
     messageEventTest.test('log warning for unknown request method', test => {
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.connect = sandbox.stub()
       wsEmitter.isConnected = sandbox.stub().returns(false)
       WebSocket.create.returns(wsEmitter)
 
-      let kmsConnection = KmsConnection.create()
+      const kmsConnection = KmsConnection.create()
 
-      let connectPromise = kmsConnection.connect()
+      const connectPromise = kmsConnection.connect()
       wsEmitter.emit('open')
 
       connectPromise
         .then(() => {
-          let unknown = JSON.stringify({ jsonrpc: '2.0', id: 'e1c609bd-e147-460b-ae61-98264bc935ad', method: 'unknown', params: { test: 1 } })
+          const unknown = JSON.stringify({ jsonrpc: '2.0', id: 'e1c609bd-e147-460b-ae61-98264bc935ad', method: 'unknown', params: { test: 1 } })
           wsEmitter.emit('message', unknown)
 
           test.ok(Logger.warn.calledWith(`Unhandled request from KMS received: ${unknown}`))
@@ -761,27 +761,27 @@ Test('KmsConnection', kmsConnTest => {
     })
 
     messageEventTest.test('complete pending request with matching response id', test => {
-      let id = 'test'
+      const id = 'test'
 
-      let requestCompleteStub = sandbox.stub()
-      let requestExistsStub = sandbox.stub()
+      const requestCompleteStub = sandbox.stub()
+      const requestExistsStub = sandbox.stub()
       Requests.create.returns({ complete: requestCompleteStub, exists: requestExistsStub })
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.connect = sandbox.stub()
       wsEmitter.isConnected = sandbox.stub().returns(false)
       WebSocket.create.returns(wsEmitter)
 
-      let kmsConnection = KmsConnection.create()
+      const kmsConnection = KmsConnection.create()
 
-      let connectPromise = kmsConnection.connect()
+      const connectPromise = kmsConnection.connect()
       wsEmitter.emit('open')
 
       requestExistsStub.withArgs(id).returns(true)
 
       connectPromise
         .then(() => {
-          let response = { jsonrpc: '2.0', id, result: { test: 1 } }
+          const response = { jsonrpc: '2.0', id, result: { test: 1 } }
           wsEmitter.emit('message', JSON.stringify(response))
 
           test.ok(requestCompleteStub.calledOnce)
@@ -793,27 +793,27 @@ Test('KmsConnection', kmsConnTest => {
     })
 
     messageEventTest.test('log warning for unknown response id', test => {
-      let id = 'test'
+      const id = 'test'
 
-      let requestCompleteStub = sandbox.stub()
-      let requestExistsStub = sandbox.stub()
+      const requestCompleteStub = sandbox.stub()
+      const requestExistsStub = sandbox.stub()
       Requests.create.returns({ complete: requestCompleteStub, exists: requestExistsStub })
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.connect = sandbox.stub()
       wsEmitter.isConnected = sandbox.stub().returns(false)
       WebSocket.create.returns(wsEmitter)
 
-      let kmsConnection = KmsConnection.create()
+      const kmsConnection = KmsConnection.create()
 
-      let connectPromise = kmsConnection.connect()
+      const connectPromise = kmsConnection.connect()
       wsEmitter.emit('open')
 
       requestExistsStub.withArgs(id).returns(false)
 
       connectPromise
         .then(() => {
-          let response = { jsonrpc: '2.0', id: 'test2', result: { test: 1 } }
+          const response = { jsonrpc: '2.0', id: 'test2', result: { test: 1 } }
           wsEmitter.emit('message', JSON.stringify(response))
 
           test.notOk(requestCompleteStub.called)

--- a/test/unit/kms/keep-alive.test.js
+++ b/test/unit/kms/keep-alive.test.js
@@ -24,8 +24,8 @@ Test('KeepAlive', keepAliveTest => {
 
   keepAliveTest.test('create should', createTest => {
     createTest.test('create new pinger and set properties', test => {
-      let pingInterval = 1000
-      let keepAlive = KeepAlive.create(pingInterval)
+      const pingInterval = 1000
+      const keepAlive = KeepAlive.create(pingInterval)
 
       test.equal(keepAlive._pingInterval, pingInterval)
       test.notOk(keepAlive._pingTimer)
@@ -37,13 +37,13 @@ Test('KeepAlive', keepAliveTest => {
 
   keepAliveTest.test('start should', startTest => {
     startTest.test('create timer to send ping on interval', test => {
-      let pingInterval = 5000
-      let ws = { ping: sandbox.stub() }
+      const pingInterval = 5000
+      const ws = { ping: sandbox.stub() }
 
-      let now = Moment()
+      const now = Moment()
       Moment.utc.returns(now)
 
-      let keepAlive = KeepAlive.create(pingInterval)
+      const keepAlive = KeepAlive.create(pingInterval)
 
       keepAlive.start(ws)
       test.ok(keepAlive._pingTimer)
@@ -56,9 +56,9 @@ Test('KeepAlive', keepAliveTest => {
     })
 
     startTest.test('do nothing if timer already started', test => {
-      let timer = {}
+      const timer = {}
 
-      let keepAlive = KeepAlive.create(1000)
+      const keepAlive = KeepAlive.create(1000)
       keepAlive._pingTimer = timer
 
       keepAlive.start({})
@@ -72,12 +72,12 @@ Test('KeepAlive', keepAliveTest => {
 
   keepAliveTest.test('stop should', stopTest => {
     stopTest.test('destroy ping timer', test => {
-      let pingInterval = 5000
-      let ws = { ping: sandbox.stub() }
+      const pingInterval = 5000
+      const ws = { ping: sandbox.stub() }
 
       sandbox.stub(global, 'clearInterval')
 
-      let keepAlive = KeepAlive.create(pingInterval)
+      const keepAlive = KeepAlive.create(pingInterval)
 
       keepAlive.start(ws)
       test.ok(keepAlive._pingTimer)
@@ -90,11 +90,11 @@ Test('KeepAlive', keepAliveTest => {
     })
 
     stopTest.test('do nothing if timer already stopped', test => {
-      let pingInterval = 5000
+      const pingInterval = 5000
 
       sandbox.stub(global, 'clearInterval')
 
-      let keepAlive = KeepAlive.create(pingInterval)
+      const keepAlive = KeepAlive.create(pingInterval)
 
       keepAlive.stop()
       test.notOk(global.clearInterval.calledOnce)

--- a/test/unit/kms/requests/index.test.js
+++ b/test/unit/kms/requests/index.test.js
@@ -17,7 +17,7 @@ Test('KMS Requests', kmsReqsTest => {
     sandbox.stub(KmsRequest, 'create')
 
     uuidStub = sandbox.stub()
-    KmsRequests = Proxyquire(`${src}/kms/requests`, { 'uuid4': uuidStub })
+    KmsRequests = Proxyquire(`${src}/kms/requests`, { uuid4: uuidStub })
 
     t.end()
   })
@@ -29,8 +29,8 @@ Test('KMS Requests', kmsReqsTest => {
 
   kmsReqsTest.test('create should', createTest => {
     createTest.test('create new requests and set properties', test => {
-      let opts = { timeout: 1000 }
-      let reqs = KmsRequests.create(opts)
+      const opts = { timeout: 1000 }
+      const reqs = KmsRequests.create(opts)
 
       test.equal(reqs._timeout, opts.timeout)
       test.deepEqual(reqs._existing, {})
@@ -42,19 +42,19 @@ Test('KMS Requests', kmsReqsTest => {
 
   kmsReqsTest.test('start should', startTest => {
     startTest.test('create a new request and return promise', test => {
-      let id = 'id'
-      let timeout = 3000
+      const id = 'id'
+      const timeout = 3000
 
       uuidStub.returns(id)
 
-      let buildStub = sandbox.stub()
-      let req = { build: buildStub, promise: {} }
+      const buildStub = sandbox.stub()
+      const req = { build: buildStub, promise: {} }
       KmsRequest.create.returns(req)
 
-      let funcStub = sandbox.stub()
-      let requests = KmsRequests.create({ timeout })
+      const funcStub = sandbox.stub()
+      const requests = KmsRequests.create({ timeout })
 
-      let promise = requests.start(funcStub)
+      const promise = requests.start(funcStub)
 
       buildStub.callArg(0)
 
@@ -66,16 +66,16 @@ Test('KMS Requests', kmsReqsTest => {
     })
 
     startTest.test('remove request after finally func called', test => {
-      let id = 'id'
+      const id = 'id'
 
       uuidStub.returns(id)
 
-      let buildStub = sandbox.stub()
-      let req = { build: buildStub, promise: {} }
+      const buildStub = sandbox.stub()
+      const req = { build: buildStub, promise: {} }
       KmsRequest.create.returns(req)
 
-      let funcStub = sandbox.stub()
-      let requests = KmsRequests.create({ timeout: 1000 })
+      const funcStub = sandbox.stub()
+      const requests = KmsRequests.create({ timeout: 1000 })
 
       requests.start(funcStub)
       test.ok(requests._existing[id])
@@ -91,9 +91,9 @@ Test('KMS Requests', kmsReqsTest => {
 
   kmsReqsTest.test('exists should', existsTest => {
     existsTest.test('return true if request id exists', test => {
-      let id = 'id1'
+      const id = 'id1'
 
-      let requests = KmsRequests.create({ timeout: 1000 })
+      const requests = KmsRequests.create({ timeout: 1000 })
       requests._existing[id] = {}
 
       test.ok(requests.exists(id))
@@ -101,7 +101,7 @@ Test('KMS Requests', kmsReqsTest => {
     })
 
     existsTest.test('return false if request id doesn\'t exist', test => {
-      let requests = KmsRequests.create({ timeout: 1000 })
+      const requests = KmsRequests.create({ timeout: 1000 })
       requests._existing['id1'] = {}
 
       test.notOk(requests.exists('id2'))
@@ -113,13 +113,13 @@ Test('KMS Requests', kmsReqsTest => {
 
   kmsReqsTest.test('complete should', completeTest => {
     completeTest.test('resolve existing request with supplied value', test => {
-      let id = 'id1'
-      let resolveStub = sandbox.stub()
+      const id = 'id1'
+      const resolveStub = sandbox.stub()
 
-      let requests = KmsRequests.create({ timeout: 1000 })
+      const requests = KmsRequests.create({ timeout: 1000 })
       requests._existing[id] = { resolve: resolveStub }
 
-      let value = 'val'
+      const value = 'val'
       requests.complete(id, value)
 
       test.ok(resolveStub.calledWith(value))
@@ -127,7 +127,7 @@ Test('KMS Requests', kmsReqsTest => {
     })
 
     completeTest.test('throw error if request id doesn\'t exist', test => {
-      let requests = KmsRequests.create({ timeout: 1000 })
+      const requests = KmsRequests.create({ timeout: 1000 })
       requests._existing['id1'] = { }
 
       try {

--- a/test/unit/kms/requests/request.test.js
+++ b/test/unit/kms/requests/request.test.js
@@ -24,7 +24,7 @@ Test('KMS Request', kmsReqTest => {
 
   kmsReqTest.test('create should', createTest => {
     createTest.test('set default properties', test => {
-      let req = KmsRequest.create()
+      const req = KmsRequest.create()
 
       test.equal(req.promise, undefined)
       test.equal(req._resolve, undefined)
@@ -37,9 +37,9 @@ Test('KMS Request', kmsReqTest => {
 
   kmsReqTest.test('build should', buildTest => {
     buildTest.test('create pending promise', test => {
-      let funcSpy = sandbox.spy()
+      const funcSpy = sandbox.spy()
 
-      let req = KmsRequest.create()
+      const req = KmsRequest.create()
       req.build(funcSpy)
 
       test.ok(req.promise)
@@ -49,7 +49,7 @@ Test('KMS Request', kmsReqTest => {
     })
 
     buildTest.test('should reject in case of error in function', test => {
-      let req = KmsRequest.create()
+      const req = KmsRequest.create()
       req.build(() => { throw new Error('err') })
 
       req.promise
@@ -64,9 +64,9 @@ Test('KMS Request', kmsReqTest => {
     })
 
     buildTest.test('reject after timeout', test => {
-      let timeout = 1000
+      const timeout = 1000
 
-      let req = KmsRequest.create()
+      const req = KmsRequest.create()
       req.build(() => {}, timeout)
 
       clock.tick(timeout + 1)
@@ -87,8 +87,8 @@ Test('KMS Request', kmsReqTest => {
 
   kmsReqTest.test('resolve should', resolveTest => {
     resolveTest.test('resolve pending promise', test => {
-      let value = 'yay'
-      let req = KmsRequest.create()
+      const value = 'yay'
+      const req = KmsRequest.create()
       req.build(() => {})
 
       req.resolve(value)
@@ -101,10 +101,10 @@ Test('KMS Request', kmsReqTest => {
     })
 
     resolveTest.test('handle no function passed in', test => {
-      let req = KmsRequest.create()
+      const req = KmsRequest.create()
       req.build()
 
-      let value = 'stuff'
+      const value = 'stuff'
       req.resolve(value)
 
       req.promise
@@ -115,10 +115,10 @@ Test('KMS Request', kmsReqTest => {
     })
 
     resolveTest.test('call finally function', test => {
-      let finallyStub = sandbox.stub().returns(P.resolve())
+      const finallyStub = sandbox.stub().returns(P.resolve())
 
-      let value = 'yay'
-      let req = KmsRequest.create()
+      const value = 'yay'
+      const req = KmsRequest.create()
       req.build(() => {}, 5000, finallyStub)
       test.notOk(finallyStub.called)
 
@@ -137,8 +137,8 @@ Test('KMS Request', kmsReqTest => {
 
   kmsReqTest.test('reject should', rejectTest => {
     rejectTest.test('reject pending promise', test => {
-      let error = new Error('bad stuff')
-      let req = KmsRequest.create()
+      const error = new Error('bad stuff')
+      const req = KmsRequest.create()
       req.build(() => {})
       req.reject(error)
 
@@ -154,10 +154,10 @@ Test('KMS Request', kmsReqTest => {
     })
 
     rejectTest.test('call finally function', test => {
-      let finallyStub = sandbox.stub().returns(P.resolve())
+      const finallyStub = sandbox.stub().returns(P.resolve())
 
-      let error = new Error('bad stuff')
-      let req = KmsRequest.create()
+      const error = new Error('bad stuff')
+      const req = KmsRequest.create()
       req.build(() => {}, 5000, finallyStub)
       test.notOk(finallyStub.called)
 

--- a/test/unit/kms/websocket.test.js
+++ b/test/unit/kms/websocket.test.js
@@ -26,7 +26,7 @@ Test('WebSocket', webSocketTest => {
     KeepAlive.create.returns(keepAliveStub)
 
     wsStub = sandbox.stub()
-    WebSocket = Proxyquire(`${src}/kms/websocket`, { 'ws': wsStub })
+    WebSocket = Proxyquire(`${src}/kms/websocket`, { ws: wsStub })
 
     clock = sandbox.useFakeTimers()
 
@@ -41,8 +41,8 @@ Test('WebSocket', webSocketTest => {
 
   webSocketTest.test('create should', createTest => {
     createTest.test('create new websocket and set properties', test => {
-      let settings = { url: 'ws://test.com', pingInterval: 5000, connectTimeout: 9000, reconnectInterval: 2000 }
-      let webSocket = WebSocket.create(settings)
+      const settings = { url: 'ws://test.com', pingInterval: 5000, connectTimeout: 9000, reconnectInterval: 2000 }
+      const webSocket = WebSocket.create(settings)
 
       test.equal(webSocket._url, settings.url)
       test.equal(webSocket._pingInterval, settings.pingInterval)
@@ -57,13 +57,13 @@ Test('WebSocket', webSocketTest => {
 
   webSocketTest.test('connect should', connectTest => {
     connectTest.test('create websocket connection and emit open event', test => {
-      let openSpy = sandbox.spy()
+      const openSpy = sandbox.spy()
 
-      let settings = { url: 'ws://test.com', pingInterval: 5000 }
-      let webSocket = WebSocket.create(settings)
+      const settings = { url: 'ws://test.com', pingInterval: 5000 }
+      const webSocket = WebSocket.create(settings)
       webSocket.on('open', openSpy)
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsStub.returns(wsEmitter)
 
       webSocket.connect()
@@ -96,15 +96,15 @@ Test('WebSocket', webSocketTest => {
     })
 
     connectTest.test('reject if connect timeout reached', test => {
-      let openSpy = sandbox.spy()
-      let errorSpy = sandbox.spy()
+      const openSpy = sandbox.spy()
+      const errorSpy = sandbox.spy()
 
-      let settings = { url: 'ws://test.com', connectTimeout: 5000 }
-      let webSocket = WebSocket.create(settings)
+      const settings = { url: 'ws://test.com', connectTimeout: 5000 }
+      const webSocket = WebSocket.create(settings)
       webSocket.on('open', openSpy)
       webSocket.on('error', errorSpy)
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.close = sandbox.stub()
       wsStub.returns(wsEmitter)
 
@@ -139,15 +139,15 @@ Test('WebSocket', webSocketTest => {
     })
 
     connectTest.test('reconnect if ECONNREFUSED error', test => {
-      let openSpy = sandbox.spy()
-      let errorSpy = sandbox.spy()
+      const openSpy = sandbox.spy()
+      const errorSpy = sandbox.spy()
 
-      let settings = { url: 'ws://test.com', connectTimeout: 5000, reconnectInterval: 1000, pingInterval: 5000 }
-      let webSocket = WebSocket.create(settings)
+      const settings = { url: 'ws://test.com', connectTimeout: 5000, reconnectInterval: 1000, pingInterval: 5000 }
+      const webSocket = WebSocket.create(settings)
       webSocket.on('open', openSpy)
       webSocket.on('error', errorSpy)
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsStub.returns(wsEmitter)
 
       webSocket.connect()
@@ -162,7 +162,7 @@ Test('WebSocket', webSocketTest => {
       test.ok(wsEmitter.listenerCount('error'), 1)
       test.equal(wsEmitter.listeners('error')[0].name.indexOf('_onError'), -1)
 
-      let error = new Error('Error connecting to websocket')
+      const error = new Error('Error connecting to websocket')
       error.code = 'ECONNREFUSED'
       wsEmitter.emit('error', error)
 
@@ -187,15 +187,15 @@ Test('WebSocket', webSocketTest => {
     })
 
     connectTest.test('reject if error event emitted', test => {
-      let openSpy = sandbox.spy()
-      let errorSpy = sandbox.spy()
+      const openSpy = sandbox.spy()
+      const errorSpy = sandbox.spy()
 
-      let settings = { url: 'ws://test.com' }
-      let webSocket = WebSocket.create(settings)
+      const settings = { url: 'ws://test.com' }
+      const webSocket = WebSocket.create(settings)
       webSocket.on('open', openSpy)
       webSocket.on('error', errorSpy)
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.close = sandbox.stub()
       wsStub.returns(wsEmitter)
 
@@ -211,7 +211,7 @@ Test('WebSocket', webSocketTest => {
       test.ok(wsEmitter.listenerCount('error'), 1)
       test.equal(wsEmitter.listeners('error')[0].name.indexOf('_onError'), -1)
 
-      let error = new Error('Error connecting to websocket')
+      const error = new Error('Error connecting to websocket')
       wsEmitter.emit('error', error)
 
       test.notOk(openSpy.calledOnce)
@@ -229,9 +229,9 @@ Test('WebSocket', webSocketTest => {
     })
 
     connectTest.test('emit open event if already connected', test => {
-      let openSpy = sandbox.spy()
+      const openSpy = sandbox.spy()
 
-      let ws = WebSocket.create({})
+      const ws = WebSocket.create({})
       ws._connected = true
       ws.on('open', openSpy)
 
@@ -247,16 +247,16 @@ Test('WebSocket', webSocketTest => {
 
   webSocketTest.test('send should', sendTest => {
     sendTest.test('call send method on internal ws if connected', test => {
-      let webSocket = WebSocket.create({})
+      const webSocket = WebSocket.create({})
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.send = sandbox.stub()
       wsStub.returns(wsEmitter)
 
       webSocket.connect()
       wsEmitter.emit('open')
 
-      let msg = 'This is a test'
+      const msg = 'This is a test'
       webSocket.send(msg)
 
       test.ok(wsEmitter.send.calledWith(msg))
@@ -265,9 +265,9 @@ Test('WebSocket', webSocketTest => {
     })
 
     sendTest.test('do nothing if internal ws not connected', test => {
-      let webSocket = WebSocket.create({})
+      const webSocket = WebSocket.create({})
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.send = sandbox.stub()
       wsStub.returns(wsEmitter)
 
@@ -283,9 +283,9 @@ Test('WebSocket', webSocketTest => {
 
   webSocketTest.test('close should', closeTest => {
     closeTest.test('call close method on internal ws if connected', test => {
-      let webSocket = WebSocket.create({})
+      const webSocket = WebSocket.create({})
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.close = sandbox.stub()
       wsStub.returns(wsEmitter)
 
@@ -300,9 +300,9 @@ Test('WebSocket', webSocketTest => {
     })
 
     closeTest.test('do nothing if internal websocket not connected', test => {
-      let webSocket = WebSocket.create({})
+      const webSocket = WebSocket.create({})
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.close = sandbox.stub()
       wsStub.returns(wsEmitter)
 
@@ -318,20 +318,20 @@ Test('WebSocket', webSocketTest => {
 
   webSocketTest.test('receiving ws close event should', closeEventTest => {
     closeEventTest.test('cleanup and emit close event', test => {
-      let closeSpy = sandbox.spy()
+      const closeSpy = sandbox.spy()
 
-      let webSocket = WebSocket.create({})
+      const webSocket = WebSocket.create({})
       webSocket.on('close', closeSpy)
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.close = sandbox.stub()
       wsStub.returns(wsEmitter)
 
       webSocket.connect()
       wsEmitter.emit('open')
 
-      let code = 100
-      let reason = 'reason'
+      const code = 100
+      const reason = 'reason'
       wsEmitter.emit('close', code, reason)
 
       test.ok(keepAliveStub.stop.calledOnce)
@@ -350,19 +350,19 @@ Test('WebSocket', webSocketTest => {
 
   webSocketTest.test('receiving ws error event should', errorEventTest => {
     errorEventTest.test('cleanup and emit error event', test => {
-      let errorSpy = sandbox.spy()
+      const errorSpy = sandbox.spy()
 
-      let webSocket = WebSocket.create({})
+      const webSocket = WebSocket.create({})
       webSocket.on('error', errorSpy)
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.close = sandbox.stub()
       wsStub.returns(wsEmitter)
 
       webSocket.connect()
       wsEmitter.emit('open')
 
-      let err = new Error()
+      const err = new Error()
       wsEmitter.emit('error', err)
 
       test.ok(keepAliveStub.stop.calledOnce)
@@ -381,16 +381,16 @@ Test('WebSocket', webSocketTest => {
 
   webSocketTest.test('receiving ws ping event should', pingEventTest => {
     pingEventTest.test('send pong', test => {
-      let webSocket = WebSocket.create({})
+      const webSocket = WebSocket.create({})
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsEmitter.pong = sandbox.stub()
       wsStub.returns(wsEmitter)
 
       webSocket.connect()
       wsEmitter.emit('open')
 
-      let data = JSON.stringify({ test: 'test' })
+      const data = JSON.stringify({ test: 'test' })
       wsEmitter.emit('ping', data)
       test.ok(wsEmitter.pong.calledWith(data))
       test.end()
@@ -401,19 +401,19 @@ Test('WebSocket', webSocketTest => {
 
   webSocketTest.test('receiving ws pong event', pongEventTest => {
     pongEventTest.test('log elapsed time since ping', test => {
-      let webSocket = WebSocket.create({})
+      const webSocket = WebSocket.create({})
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsStub.returns(wsEmitter)
 
       webSocket.connect()
       wsEmitter.emit('open')
 
-      let now = Moment()
+      const now = Moment()
       Moment.utc.returns(now)
 
-      let timestamp = Moment(now).subtract(5, 'seconds')
-      let data = JSON.stringify({ timestamp: timestamp.toISOString() })
+      const timestamp = Moment(now).subtract(5, 'seconds')
+      const data = JSON.stringify({ timestamp: timestamp.toISOString() })
 
       wsEmitter.emit('pong', data)
       test.ok(Logger.info.calledWith('Received pong, elapsed 5000ms'))
@@ -425,18 +425,18 @@ Test('WebSocket', webSocketTest => {
 
   webSocketTest.test('receiving ws message event should', messageEventTest => {
     messageEventTest.test('emit message event', test => {
-      let messageSpy = sandbox.spy()
+      const messageSpy = sandbox.spy()
 
-      let webSocket = WebSocket.create({})
+      const webSocket = WebSocket.create({})
       webSocket.on('message', messageSpy)
 
-      let wsEmitter = new EventEmitter()
+      const wsEmitter = new EventEmitter()
       wsStub.returns(wsEmitter)
 
       webSocket.connect()
       wsEmitter.emit('open')
 
-      let msg = 'This is a test'
+      const msg = 'This is a test'
       wsEmitter.emit('message', msg)
 
       test.ok(messageSpy.calledWith(msg))

--- a/test/unit/lib/migrator.test.js
+++ b/test/unit/lib/migrator.test.js
@@ -32,7 +32,7 @@ Test('Migrator', migratorTest => {
     migrateTest.test('override migrations directory path and run migrations', test => {
       Migrations.migrate.returns(P.resolve())
 
-      let updatedMigrationsPath = Path.join(process.cwd(), configuredMigrationsFolder)
+      const updatedMigrationsPath = Path.join(process.cwd(), configuredMigrationsFolder)
 
       Migrator.migrate()
         .then(() => {

--- a/test/unit/server.test.js
+++ b/test/unit/server.test.js
@@ -21,13 +21,13 @@ Test('Server', serverTest => {
   let oldKmsConfig
   let oldDatabaseUri
   let oldBatchTimeInterval
-  let port = 1234
-  let batchSize = 5
-  let batchTimeInterval = 30000
-  let healthPort = 2345
-  let service = 'MyService'
-  let kmsConfig = { 'URL': 'ws://test.com', 'PING_INTERVAL': 10000, 'REQUEST_TIMEOUT': 15000, 'CONNECT_TIMEOUT': 8000, 'RECONNECT_INTERVAL': 2000 }
-  let databaseUri = 'some-database-uri'
+  const port = 1234
+  const batchSize = 5
+  const batchTimeInterval = 30000
+  const healthPort = 2345
+  const service = 'MyService'
+  const kmsConfig = { URL: 'ws://test.com', PING_INTERVAL: 10000, REQUEST_TIMEOUT: 15000, CONNECT_TIMEOUT: 8000, RECONNECT_INTERVAL: 2000 }
+  const databaseUri = 'some-database-uri'
 
   serverTest.beforeEach(t => {
     sandbox = Sinon.sandbox.create()
@@ -74,10 +74,10 @@ Test('Server', serverTest => {
       Db.connect.returns(P.resolve({}))
       Migrator.migrate.returns(P.resolve({}))
 
-      let startStub = sandbox.stub()
+      const startStub = sandbox.stub()
       startStub.returns(P.resolve())
 
-      let sidecar = new EventEmitter()
+      const sidecar = new EventEmitter()
       sidecar.id = 'id'
       sidecar.service = 'test-service'
       sidecar.port = 1234
@@ -114,15 +114,15 @@ Test('Server', serverTest => {
     })
 
     setupTest.test('cleanup and rethrow on error', test => {
-      let error = new Error()
+      const error = new Error()
 
       Db.connect.returns(P.resolve({}))
       Migrator.migrate.returns(P.resolve({}))
 
-      let startStub = sandbox.stub()
+      const startStub = sandbox.stub()
       startStub.returns(P.reject(error))
 
-      let sidecar = new EventEmitter()
+      const sidecar = new EventEmitter()
       sidecar.start = startStub
       Sidecar.create.returns(sidecar)
 
@@ -143,14 +143,14 @@ Test('Server', serverTest => {
       Db.connect.returns(P.resolve({}))
       Migrator.migrate.returns(P.resolve({}))
 
-      let startStub = sandbox.stub()
+      const startStub = sandbox.stub()
       startStub.returns(P.resolve())
 
-      let sidecar = new EventEmitter()
+      const sidecar = new EventEmitter()
       sidecar.start = startStub
       Sidecar.create.returns(sidecar)
 
-      let p = require('../../src/server')
+      const p = require('../../src/server')
 
       p.then(() => {
         try {

--- a/test/unit/sidecar.test.js
+++ b/test/unit/sidecar.test.js
@@ -39,7 +39,7 @@ Test('Sidecar', sidecarTest => {
     sandbox.stub(Health)
     uuidStub = sandbox.stub()
 
-    Sidecar = Proxyquire(`${src}/sidecar`, { 'uuid4': uuidStub })
+    Sidecar = Proxyquire(`${src}/sidecar`, { uuid4: uuidStub })
 
     t.end()
   })
@@ -51,23 +51,23 @@ Test('Sidecar', sidecarTest => {
 
   sidecarTest.test('create should', createTest => {
     createTest.test('create new sidecar and setup', test => {
-      let now = new Date()
+      const now = new Date()
       Moment.utc.returns(now)
 
-      let sidecarId = 'sidecar-id'
+      const sidecarId = 'sidecar-id'
       uuidStub.returns(sidecarId)
 
-      let kmsOnStub = sandbox.stub()
-      KmsConnection.create.returns({ 'on': kmsOnStub })
+      const kmsOnStub = sandbox.stub()
+      KmsConnection.create.returns({ on: kmsOnStub })
 
-      let socketOnStub = sandbox.stub()
-      SocketListener.create.returns({ 'on': socketOnStub })
+      const socketOnStub = sandbox.stub()
+      SocketListener.create.returns({ on: socketOnStub })
 
-      let batchTrackerOnStub = sandbox.stub()
-      BatchTracker.create.returns({ 'on': batchTrackerOnStub })
+      const batchTrackerOnStub = sandbox.stub()
+      BatchTracker.create.returns({ on: batchTrackerOnStub })
 
-      let settings = { serviceName: 'test-service', kms: { url: 'ws://test.com', pingInterval: 30000, requestTimeout: 15000, connectTimeout: 9000, reconnectInterval: 2000 }, port: 1234, batchSize: 50, batchTimeInterval: 45000, version: '1.2.3', healthPort: 2345 }
-      let sidecar = Sidecar.create(settings)
+      const settings = { serviceName: 'test-service', kms: { url: 'ws://test.com', pingInterval: 30000, requestTimeout: 15000, connectTimeout: 9000, reconnectInterval: 2000 }, port: 1234, batchSize: 50, batchTimeInterval: 45000, version: '1.2.3', healthPort: 2345 }
+      const sidecar = Sidecar.create(settings)
 
       test.equal(sidecar.id, sidecarId)
       test.equal(sidecar.port, settings.port)
@@ -96,33 +96,33 @@ Test('Sidecar', sidecarTest => {
 
   sidecarTest.test('start should', startTest => {
     startTest.test('save sidecar to datastore then register with KMS then start SocketListener listening', test => {
-      let now = new Date()
+      const now = new Date()
       Moment.utc.returns(now)
 
-      let sidecarId = 'sidecar-id'
+      const sidecarId = 'sidecar-id'
       uuidStub.returns(sidecarId)
 
-      let connectStub = sandbox.stub()
+      const connectStub = sandbox.stub()
       connectStub.returns(P.resolve())
 
-      let keys = { batchKey: 'batch', rowKey: 'row' }
-      let registerStub = sandbox.stub()
+      const keys = { batchKey: 'batch', rowKey: 'row' }
+      const registerStub = sandbox.stub()
       registerStub.returns(P.resolve(keys))
 
-      let keyStore = { store: sandbox.stub() }
+      const keyStore = { store: sandbox.stub() }
       Keys.create.returns(keyStore)
 
-      KmsConnection.create.returns({ connect: connectStub, register: registerStub, 'on': sandbox.stub() })
+      KmsConnection.create.returns({ connect: connectStub, register: registerStub, on: sandbox.stub() })
 
-      BatchTracker.create.returns({ 'on': sandbox.stub() })
+      BatchTracker.create.returns({ on: sandbox.stub() })
 
-      let listenStub = sandbox.stub()
-      SocketListener.create.returns({ 'on': sandbox.stub(), listen: listenStub })
+      const listenStub = sandbox.stub()
+      SocketListener.create.returns({ on: sandbox.stub(), listen: listenStub })
 
       SidecarService.create.returns(P.resolve())
 
-      let settings = { serviceName: 'test-service', kmsUrl: 'ws://test.com', kmsPingInterval: 30000, port: 1234, batchSize: 50, version: '1.2.3', healthPort: 2345 }
-      let sidecar = Sidecar.create(settings)
+      const settings = { serviceName: 'test-service', kmsUrl: 'ws://test.com', kmsPingInterval: 30000, port: 1234, batchSize: 50, version: '1.2.3', healthPort: 2345 }
+      const sidecar = Sidecar.create(settings)
 
       sidecar.start()
         .then(() => {
@@ -142,31 +142,31 @@ Test('Sidecar', sidecarTest => {
 
   sidecarTest.test('stop should', stopTest => {
     stopTest.test('stop services and emit close event', test => {
-      let connectStub = sandbox.stub()
+      const connectStub = sandbox.stub()
       connectStub.returns(P.resolve())
 
-      let keys = { batchKey: 'batch', rowKey: 'row' }
-      let registerStub = sandbox.stub()
+      const keys = { batchKey: 'batch', rowKey: 'row' }
+      const registerStub = sandbox.stub()
       registerStub.returns(P.resolve(keys))
 
-      let keyStore = { store: sandbox.stub() }
+      const keyStore = { store: sandbox.stub() }
       Keys.create.returns(keyStore)
 
-      let kmsCloseStub = sandbox.stub()
+      const kmsCloseStub = sandbox.stub()
 
-      KmsConnection.create.returns({ connect: connectStub, register: registerStub, 'on': sandbox.stub(), close: kmsCloseStub })
+      KmsConnection.create.returns({ connect: connectStub, register: registerStub, on: sandbox.stub(), close: kmsCloseStub })
 
-      BatchTracker.create.returns({ 'on': sandbox.stub() })
+      BatchTracker.create.returns({ on: sandbox.stub() })
 
-      let listenStub = sandbox.stub()
-      let socketCloseStub = sandbox.stub()
-      SocketListener.create.returns({ 'on': sandbox.stub(), listen: listenStub, close: socketCloseStub })
+      const listenStub = sandbox.stub()
+      const socketCloseStub = sandbox.stub()
+      SocketListener.create.returns({ on: sandbox.stub(), listen: listenStub, close: socketCloseStub })
 
       SidecarService.create.returns(P.resolve())
 
-      let closeSpy = sandbox.spy()
-      let settings = { serviceName: 'test-service', kmsUrl: 'ws://test.com', kmsPingInterval: 30000, port: 1234, batchSize: 50, version: '1.2.3', healthPort: 2345 }
-      let sidecar = Sidecar.create(settings)
+      const closeSpy = sandbox.spy()
+      const settings = { serviceName: 'test-service', kmsUrl: 'ws://test.com', kmsPingInterval: 30000, port: 1234, batchSize: 50, version: '1.2.3', healthPort: 2345 }
+      const sidecar = Sidecar.create(settings)
       sidecar.on('close', closeSpy)
 
       sidecar.start()
@@ -185,48 +185,48 @@ Test('Sidecar', sidecarTest => {
 
   sidecarTest.test('receving KMS connectionClose event should', kmsCloseTest => {
     kmsCloseTest.test('attempt to reconnect to KMS if canReconnet flag true', test => {
-      let id = 'id1'
-      let reconnectId = 'id2'
+      const id = 'id1'
+      const reconnectId = 'id2'
 
       uuidStub.onFirstCall().returns(id)
       uuidStub.onSecondCall().returns(reconnectId)
 
-      let now = new Date()
-      let reconnectNow = Moment(now).add(1, 'day')
+      const now = new Date()
+      const reconnectNow = Moment(now).add(1, 'day')
 
       Moment.utc.returns(reconnectNow)
 
-      let connectStub = sandbox.stub()
-      let connectPromise = P.resolve()
+      const connectStub = sandbox.stub()
+      const connectPromise = P.resolve()
       connectStub.returns(connectPromise)
 
-      let reconnectKeys = { batchKey: 'reconnect-batch', rowKey: 'reconnect-row' }
+      const reconnectKeys = { batchKey: 'reconnect-batch', rowKey: 'reconnect-row' }
 
-      let storePromise = P.resolve()
-      let keyStore = { store: sandbox.stub().returns(storePromise) }
+      const storePromise = P.resolve()
+      const keyStore = { store: sandbox.stub().returns(storePromise) }
       Keys.create.returns(keyStore)
 
-      let registerStub = sandbox.stub()
-      let registerPromise = P.resolve(reconnectKeys)
+      const registerStub = sandbox.stub()
+      const registerPromise = P.resolve(reconnectKeys)
       registerStub.returns(registerPromise)
 
-      let kmsConnection = new EventEmitter()
+      const kmsConnection = new EventEmitter()
       kmsConnection.connect = connectStub
       kmsConnection.register = registerStub
       KmsConnection.create.returns(kmsConnection)
 
-      BatchTracker.create.returns({ 'on': sandbox.stub() })
+      BatchTracker.create.returns({ on: sandbox.stub() })
 
-      let resumePromise = P.resolve()
-      let pausePromise = P.resolve()
-      let socketListener = { 'on': sandbox.stub(), listen: sandbox.stub(), pause: sandbox.stub().returns(pausePromise), resume: sandbox.stub().returns(resumePromise) }
+      const resumePromise = P.resolve()
+      const pausePromise = P.resolve()
+      const socketListener = { on: sandbox.stub(), listen: sandbox.stub(), pause: sandbox.stub().returns(pausePromise), resume: sandbox.stub().returns(resumePromise) }
       SocketListener.create.returns(socketListener)
 
-      let reconnectCreatePromise = P.resolve()
+      const reconnectCreatePromise = P.resolve()
       SidecarService.create.returns(reconnectCreatePromise)
 
-      let settings = { serviceName: 'test-service', kmsUrl: 'ws://test.com', kmsPingInterval: 30000, port: 1234, batchSize: 50, version: '1.2.3', healthPort: 2345 }
-      let sidecar = Sidecar.create(settings)
+      const settings = { serviceName: 'test-service', kmsUrl: 'ws://test.com', kmsPingInterval: 30000, port: 1234, batchSize: 50, version: '1.2.3', healthPort: 2345 }
+      const sidecar = Sidecar.create(settings)
 
       test.equal(sidecar.id, id)
       test.equal(sidecar.startTime, reconnectNow)
@@ -266,52 +266,52 @@ Test('Sidecar', sidecarTest => {
     })
 
     kmsCloseTest.test('stop sidecar if error during reconnect attempt', test => {
-      let id = 'id1'
-      let reconnectId = 'id2'
+      const id = 'id1'
+      const reconnectId = 'id2'
 
       uuidStub.onFirstCall().returns(id)
       uuidStub.onSecondCall().returns(reconnectId)
 
-      let now = new Date()
-      let reconnectNow = Moment(now).add(1, 'day')
+      const now = new Date()
+      const reconnectNow = Moment(now).add(1, 'day')
 
       Moment.utc.returns(reconnectNow)
 
-      let connectStub = sandbox.stub()
-      let connectPromise = P.resolve()
+      const connectStub = sandbox.stub()
+      const connectPromise = P.resolve()
       connectStub.returns(connectPromise)
 
-      let reconnectKeys = { batchKey: 'reconnect-batch', rowKey: 'reconnect-row' }
+      const reconnectKeys = { batchKey: 'reconnect-batch', rowKey: 'reconnect-row' }
 
-      let storePromise = P.resolve()
-      let keyStore = { store: sandbox.stub().returns(storePromise) }
+      const storePromise = P.resolve()
+      const keyStore = { store: sandbox.stub().returns(storePromise) }
       Keys.create.returns(keyStore)
 
-      let registerStub = sandbox.stub()
-      let registerPromise = P.resolve(reconnectKeys)
+      const registerStub = sandbox.stub()
+      const registerPromise = P.resolve(reconnectKeys)
       registerStub.returns(registerPromise)
 
-      let kmsConnection = new EventEmitter()
+      const kmsConnection = new EventEmitter()
       kmsConnection.connect = connectStub
       kmsConnection.register = registerStub
       kmsConnection.close = sandbox.stub()
       KmsConnection.create.returns(kmsConnection)
 
-      BatchTracker.create.returns({ 'on': sandbox.stub() })
+      BatchTracker.create.returns({ on: sandbox.stub() })
 
-      let resumeError = new Error('Bad error')
-      let resumePromise = P.reject(resumeError)
-      let socketCloseStub = sandbox.stub()
-      let pausePromise = P.resolve()
-      let socketListener = { 'on': sandbox.stub(), listen: sandbox.stub(), pause: sandbox.stub().returns(pausePromise), close: socketCloseStub, resume: sandbox.stub().returns(resumePromise) }
+      const resumeError = new Error('Bad error')
+      const resumePromise = P.reject(resumeError)
+      const socketCloseStub = sandbox.stub()
+      const pausePromise = P.resolve()
+      const socketListener = { on: sandbox.stub(), listen: sandbox.stub(), pause: sandbox.stub().returns(pausePromise), close: socketCloseStub, resume: sandbox.stub().returns(resumePromise) }
       SocketListener.create.returns(socketListener)
 
-      let reconnectCreatePromise = P.resolve()
+      const reconnectCreatePromise = P.resolve()
       SidecarService.create.returns(reconnectCreatePromise)
 
-      let closeSpy = sandbox.spy()
-      let settings = { serviceName: 'test-service', kmsUrl: 'ws://test.com', kmsPingInterval: 30000, port: 1234, batchSize: 50, version: '1.2.3' }
-      let sidecar = Sidecar.create(settings)
+      const closeSpy = sandbox.spy()
+      const settings = { serviceName: 'test-service', kmsUrl: 'ws://test.com', kmsPingInterval: 30000, port: 1234, batchSize: 50, version: '1.2.3' }
+      const sidecar = Sidecar.create(settings)
       sidecar.on('close', closeSpy)
 
       test.equal(sidecar.id, id)
@@ -359,32 +359,32 @@ Test('Sidecar', sidecarTest => {
     })
 
     kmsCloseTest.test('stop sidecar if canReconnect flag flase', test => {
-      let connectStub = sandbox.stub()
+      const connectStub = sandbox.stub()
       connectStub.returns(P.resolve())
 
-      let keys = { batchKey: 'batch', rowKey: 'row' }
-      let registerStub = sandbox.stub()
+      const keys = { batchKey: 'batch', rowKey: 'row' }
+      const registerStub = sandbox.stub()
       registerStub.returns(P.resolve(keys))
 
-      let keyStore = { store: sandbox.stub() }
+      const keyStore = { store: sandbox.stub() }
       Keys.create.returns(keyStore)
 
-      let kmsConnection = new EventEmitter()
+      const kmsConnection = new EventEmitter()
       kmsConnection.connect = connectStub
       kmsConnection.register = registerStub
       kmsConnection.close = sandbox.stub()
       KmsConnection.create.returns(kmsConnection)
 
-      BatchTracker.create.returns({ 'on': sandbox.stub() })
+      BatchTracker.create.returns({ on: sandbox.stub() })
 
-      let socketCloseStub = sandbox.stub()
-      SocketListener.create.returns({ 'on': sandbox.stub(), listen: sandbox.stub(), close: socketCloseStub })
+      const socketCloseStub = sandbox.stub()
+      SocketListener.create.returns({ on: sandbox.stub(), listen: sandbox.stub(), close: socketCloseStub })
 
       SidecarService.create.returns(P.resolve())
 
-      let closeSpy = sandbox.spy()
-      let settings = { serviceName: 'test-service', kmsUrl: 'ws://test.com', kmsPingInterval: 30000, port: 1234, batchSize: 50, version: '1.2.3' }
-      let sidecar = Sidecar.create(settings)
+      const closeSpy = sandbox.spy()
+      const settings = { serviceName: 'test-service', kmsUrl: 'ws://test.com', kmsPingInterval: 30000, port: 1234, batchSize: 50, version: '1.2.3' }
+      const sidecar = Sidecar.create(settings)
       sidecar.on('close', closeSpy)
 
       sidecar.start()
@@ -404,44 +404,44 @@ Test('Sidecar', sidecarTest => {
 
   sidecarTest.test('receving KMS inquiry event should', inquiryTest => {
     inquiryTest.test('find batches for inquiry and send to KMS', test => {
-      let connectStub = sandbox.stub()
+      const connectStub = sandbox.stub()
       connectStub.returns(P.resolve())
 
-      let keys = { batchKey: 'batch', rowKey: 'row' }
-      let registerStub = sandbox.stub()
+      const keys = { batchKey: 'batch', rowKey: 'row' }
+      const registerStub = sandbox.stub()
       registerStub.returns(P.resolve(keys))
 
-      let keyStore = { store: sandbox.stub() }
+      const keyStore = { store: sandbox.stub() }
       Keys.create.returns(keyStore)
 
-      let kmsConnection = new EventEmitter()
+      const kmsConnection = new EventEmitter()
       kmsConnection.connect = connectStub
       kmsConnection.register = registerStub
       kmsConnection.respondToInquiry = sandbox.stub().returns(P.resolve())
       KmsConnection.create.returns(kmsConnection)
 
-      SocketListener.create.returns({ 'on': sandbox.stub(), listen: sandbox.stub() })
+      SocketListener.create.returns({ on: sandbox.stub(), listen: sandbox.stub() })
 
-      BatchTracker.create.returns({ 'on': sandbox.stub() })
+      BatchTracker.create.returns({ on: sandbox.stub() })
 
-      let found = [{ batchId: 'batch1', data: 'data' }, { batchId: 'batch2', data: 'data2' }]
-      let findPromise = P.resolve(found)
+      const found = [{ batchId: 'batch1', data: 'data' }, { batchId: 'batch2', data: 'data2' }]
+      const findPromise = P.resolve(found)
       BatchService.findForService.returns(findPromise)
 
-      let sendId = 'send-id'
-      let sendId2 = 'send-id2'
+      const sendId = 'send-id'
+      const sendId2 = 'send-id2'
       uuidStub.onSecondCall().returns(sendId)
       uuidStub.onThirdCall().returns(sendId2)
 
       SidecarService.create.returns(P.resolve())
 
-      let settings = { serviceName: 'test-service', kmsUrl: 'ws://test.com', kmsPingInterval: 30000, port: 1234, batchSize: 50, version: '1.2.3' }
-      let sidecar = Sidecar.create(settings)
+      const settings = { serviceName: 'test-service', kmsUrl: 'ws://test.com', kmsPingInterval: 30000, port: 1234, batchSize: 50, version: '1.2.3' }
+      const sidecar = Sidecar.create(settings)
 
-      let now = Moment()
-      let start = Moment(now).subtract(1, 'month')
+      const now = Moment()
+      const start = Moment(now).subtract(1, 'month')
 
-      let request = { id: 'id', inquiryId: 'inquiry-id', startTime: start.toISOString(), endTime: now.toISOString() }
+      const request = { id: 'id', inquiryId: 'inquiry-id', startTime: start.toISOString(), endTime: now.toISOString() }
       sidecar.start()
         .then(() => {
           kmsConnection.emit('inquiry', request)
@@ -462,36 +462,36 @@ Test('Sidecar', sidecarTest => {
 
   sidecarTest.test('receving KMS healthCheck event should', healthCheckTest => {
     healthCheckTest.test('run healthcheck and send response to KMS if ping', test => {
-      let connectStub = sandbox.stub()
+      const connectStub = sandbox.stub()
       connectStub.returns(P.resolve())
 
-      let keys = { batchKey: 'batch', rowKey: 'row' }
-      let registerStub = sandbox.stub()
+      const keys = { batchKey: 'batch', rowKey: 'row' }
+      const registerStub = sandbox.stub()
       registerStub.returns(P.resolve(keys))
 
-      let keyStore = { store: sandbox.stub() }
+      const keyStore = { store: sandbox.stub() }
       Keys.create.returns(keyStore)
 
-      let kmsConnection = new EventEmitter()
+      const kmsConnection = new EventEmitter()
       kmsConnection.connect = connectStub
       kmsConnection.register = registerStub
       kmsConnection.respondToHealthCheck = sandbox.stub().returns(P.resolve())
       KmsConnection.create.returns(kmsConnection)
 
-      SocketListener.create.returns({ 'on': sandbox.stub(), listen: sandbox.stub() })
+      SocketListener.create.returns({ on: sandbox.stub(), listen: sandbox.stub() })
 
-      BatchTracker.create.returns({ 'on': sandbox.stub() })
+      BatchTracker.create.returns({ on: sandbox.stub() })
 
-      let healthCheck = {}
-      let healthCheckPromise = P.resolve(healthCheck)
+      const healthCheck = {}
+      const healthCheckPromise = P.resolve(healthCheck)
       HealthCheck.ping.returns(healthCheckPromise)
 
       SidecarService.create.returns(P.resolve())
 
-      let settings = { serviceName: 'test-service', kmsUrl: 'ws://test.com', kmsPingInterval: 30000, port: 1234, batchSize: 50, version: '1.2.3' }
-      let sidecar = Sidecar.create(settings)
+      const settings = { serviceName: 'test-service', kmsUrl: 'ws://test.com', kmsPingInterval: 30000, port: 1234, batchSize: 50, version: '1.2.3' }
+      const sidecar = Sidecar.create(settings)
 
-      let request = { id: 1, 'level': 'ping' }
+      const request = { id: 1, level: 'ping' }
       sidecar.start()
         .then(() => {
           kmsConnection.emit('healthCheck', request)
@@ -507,31 +507,31 @@ Test('Sidecar', sidecarTest => {
     })
 
     healthCheckTest.test('do not run healthcheck if level is not ping', test => {
-      let connectStub = sandbox.stub()
+      const connectStub = sandbox.stub()
       connectStub.returns(P.resolve())
 
-      let keys = { batchKey: 'batch', rowKey: 'row' }
-      let registerStub = sandbox.stub()
+      const keys = { batchKey: 'batch', rowKey: 'row' }
+      const registerStub = sandbox.stub()
       registerStub.returns(P.resolve(keys))
 
-      let keyStore = { store: sandbox.stub() }
+      const keyStore = { store: sandbox.stub() }
       Keys.create.returns(keyStore)
 
-      let kmsConnection = new EventEmitter()
+      const kmsConnection = new EventEmitter()
       kmsConnection.connect = connectStub
       kmsConnection.register = registerStub
       KmsConnection.create.returns(kmsConnection)
 
-      SocketListener.create.returns({ 'on': sandbox.stub(), listen: sandbox.stub() })
+      SocketListener.create.returns({ on: sandbox.stub(), listen: sandbox.stub() })
 
-      BatchTracker.create.returns({ 'on': sandbox.stub() })
+      BatchTracker.create.returns({ on: sandbox.stub() })
 
       SidecarService.create.returns(P.resolve())
 
-      let settings = { serviceName: 'test-service', kmsUrl: 'ws://test.com', kmsPingInterval: 30000, port: 1234, batchSize: 50, version: '1.2.3' }
-      let sidecar = Sidecar.create(settings)
+      const settings = { serviceName: 'test-service', kmsUrl: 'ws://test.com', kmsPingInterval: 30000, port: 1234, batchSize: 50, version: '1.2.3' }
+      const sidecar = Sidecar.create(settings)
 
-      let request = { id: 1, 'level': 'details' }
+      const request = { id: 1, level: 'details' }
       sidecar.start()
         .then(() => {
           kmsConnection.emit('healthCheck', request)
@@ -546,38 +546,38 @@ Test('Sidecar', sidecarTest => {
 
   sidecarTest.test('receiving SocketListener message event should', messageTest => {
     messageTest.test('increment sequence and save received message as an event', test => {
-      let startSequence = 5
+      const startSequence = 5
 
-      let connectStub = sandbox.stub()
+      const connectStub = sandbox.stub()
       connectStub.returns(P.resolve())
 
-      let keys = { batchKey: 'batch', rowKey: 'row' }
-      let registerStub = sandbox.stub()
+      const keys = { batchKey: 'batch', rowKey: 'row' }
+      const registerStub = sandbox.stub()
       registerStub.returns(P.resolve(keys))
 
-      let keyStore = { store: sandbox.stub(), getRowKey: sandbox.stub().returns(keys.rowKey) }
+      const keyStore = { store: sandbox.stub(), getRowKey: sandbox.stub().returns(keys.rowKey) }
       Keys.create.returns(keyStore)
 
-      KmsConnection.create.returns({ connect: connectStub, register: registerStub, 'on': sandbox.stub() })
+      KmsConnection.create.returns({ connect: connectStub, register: registerStub, on: sandbox.stub() })
 
-      let eventCreatedStub = sandbox.stub()
-      BatchTracker.create.returns({ eventCreated: eventCreatedStub, 'on': sandbox.stub() })
+      const eventCreatedStub = sandbox.stub()
+      BatchTracker.create.returns({ eventCreated: eventCreatedStub, on: sandbox.stub() })
 
-      let socketListener = new EventEmitter()
+      const socketListener = new EventEmitter()
       socketListener.listen = sandbox.stub()
       SocketListener.create.returns(socketListener)
 
-      let event = { eventId: 'event-id', sequence: startSequence + 1 }
-      let eventPromise = P.resolve(event)
+      const event = { eventId: 'event-id', sequence: startSequence + 1 }
+      const eventPromise = P.resolve(event)
       EventService.create.returns(eventPromise)
 
       SidecarService.create.returns(P.resolve())
 
-      let settings = { serviceName: 'test-service', kmsUrl: 'ws://test.com', kmsPingInterval: 30000, port: 1234, batchSize: 50, version: '1.2.3' }
-      let sidecar = Sidecar.create(settings)
+      const settings = { serviceName: 'test-service', kmsUrl: 'ws://test.com', kmsPingInterval: 30000, port: 1234, batchSize: 50, version: '1.2.3' }
+      const sidecar = Sidecar.create(settings)
       sidecar._sequence = startSequence
 
-      let msg = JSON.stringify({ id: 1, name: 'test' })
+      const msg = JSON.stringify({ id: 1, name: 'test' })
       sidecar.start()
         .then(() => {
           socketListener.emit('message', msg)
@@ -599,41 +599,41 @@ Test('Sidecar', sidecarTest => {
 
   sidecarTest.test('receiving BatchTracker batchReady event should', messageTest => {
     messageTest.test('create batch from received event ids and send to KMS', test => {
-      let batchId = 'batch-id'
-      let batchSignature = 'sig'
+      const batchId = 'batch-id'
+      const batchSignature = 'sig'
 
-      let connectStub = sandbox.stub()
+      const connectStub = sandbox.stub()
       connectStub.returns(P.resolve())
 
-      let keys = { batchKey: 'batch', rowKey: 'row' }
-      let registerStub = sandbox.stub()
+      const keys = { batchKey: 'batch', rowKey: 'row' }
+      const registerStub = sandbox.stub()
       registerStub.returns(P.resolve(keys))
 
-      let keyStore = { store: sandbox.stub(), getBatchKey: sandbox.stub().returns(keys.batchKey) }
+      const keyStore = { store: sandbox.stub(), getBatchKey: sandbox.stub().returns(keys.batchKey) }
       Keys.create.returns(keyStore)
 
-      let kmsBatchResponse = { result: { id: batchId } }
-      let kmsBatchPromise = P.resolve(kmsBatchResponse)
-      let sendBatchStub = sandbox.stub().returns(kmsBatchPromise)
+      const kmsBatchResponse = { result: { id: batchId } }
+      const kmsBatchPromise = P.resolve(kmsBatchResponse)
+      const sendBatchStub = sandbox.stub().returns(kmsBatchPromise)
 
-      KmsConnection.create.returns({ connect: connectStub, register: registerStub, sendBatch: sendBatchStub, 'on': sandbox.stub() })
+      KmsConnection.create.returns({ connect: connectStub, register: registerStub, sendBatch: sendBatchStub, on: sandbox.stub() })
 
-      SocketListener.create.returns({ 'on': sandbox.stub(), listen: sandbox.stub() })
+      SocketListener.create.returns({ on: sandbox.stub(), listen: sandbox.stub() })
 
-      let batchTracker = new EventEmitter()
+      const batchTracker = new EventEmitter()
       batchTracker.event = sandbox.stub()
       BatchTracker.create.returns(batchTracker)
 
-      let batchEventIds = [1, 2]
+      const batchEventIds = [1, 2]
 
-      let batch = { batchId, signature: batchSignature }
-      let batchPromise = P.resolve(batch)
+      const batch = { batchId, signature: batchSignature }
+      const batchPromise = P.resolve(batch)
       BatchService.create.returns(batchPromise)
 
       SidecarService.create.returns(P.resolve())
 
-      let settings = { serviceName: 'test-service', kmsUrl: 'ws://test.com', kmsPingInterval: 30000, port: 1234, batchSize: 50, version: '1.2.3' }
-      let sidecar = Sidecar.create(settings)
+      const settings = { serviceName: 'test-service', kmsUrl: 'ws://test.com', kmsPingInterval: 30000, port: 1234, batchSize: 50, version: '1.2.3' }
+      const sidecar = Sidecar.create(settings)
 
       sidecar.start()
         .then(() => {
@@ -652,41 +652,41 @@ Test('Sidecar', sidecarTest => {
     })
 
     messageTest.test('log error if thrown while sending batch to KMS', test => {
-      let batchId = 'batch-id'
-      let batchSignature = 'sig'
+      const batchId = 'batch-id'
+      const batchSignature = 'sig'
 
-      let connectStub = sandbox.stub()
+      const connectStub = sandbox.stub()
       connectStub.returns(P.resolve())
 
-      let keys = { batchKey: 'batch', rowKey: 'row' }
-      let registerStub = sandbox.stub()
+      const keys = { batchKey: 'batch', rowKey: 'row' }
+      const registerStub = sandbox.stub()
       registerStub.returns(P.resolve(keys))
 
-      let keyStore = { store: sandbox.stub(), getBatchKey: sandbox.stub().returns(keys.batchKey) }
+      const keyStore = { store: sandbox.stub(), getBatchKey: sandbox.stub().returns(keys.batchKey) }
       Keys.create.returns(keyStore)
 
-      let err = new Error('error sending batch')
-      let kmsBatchPromise = P.reject(err)
-      let sendBatchStub = sandbox.stub().returns(kmsBatchPromise)
+      const err = new Error('error sending batch')
+      const kmsBatchPromise = P.reject(err)
+      const sendBatchStub = sandbox.stub().returns(kmsBatchPromise)
 
-      KmsConnection.create.returns({ connect: connectStub, register: registerStub, sendBatch: sendBatchStub, 'on': sandbox.stub() })
+      KmsConnection.create.returns({ connect: connectStub, register: registerStub, sendBatch: sendBatchStub, on: sandbox.stub() })
 
-      SocketListener.create.returns({ 'on': sandbox.stub(), listen: sandbox.stub() })
+      SocketListener.create.returns({ on: sandbox.stub(), listen: sandbox.stub() })
 
-      let batchTracker = new EventEmitter()
+      const batchTracker = new EventEmitter()
       batchTracker.event = sandbox.stub()
       BatchTracker.create.returns(batchTracker)
 
-      let batchEventIds = [1, 2]
+      const batchEventIds = [1, 2]
 
-      let batch = { batchId, signature: batchSignature }
-      let batchPromise = P.resolve(batch)
+      const batch = { batchId, signature: batchSignature }
+      const batchPromise = P.resolve(batch)
       BatchService.create.returns(batchPromise)
 
       SidecarService.create.returns(P.resolve())
 
-      let settings = { serviceName: 'test-service', kmsUrl: 'ws://test.com', kmsPingInterval: 30000, port: 1234, batchSize: 50, version: '1.2.3' }
-      let sidecar = Sidecar.create(settings)
+      const settings = { serviceName: 'test-service', kmsUrl: 'ws://test.com', kmsPingInterval: 30000, port: 1234, batchSize: 50, version: '1.2.3' }
+      const sidecar = Sidecar.create(settings)
 
       sidecar.start()
         .then(() => {

--- a/test/unit/socket/connection.test.js
+++ b/test/unit/socket/connection.test.js
@@ -22,10 +22,10 @@ Test('TcpConnection', tcpConnTest => {
 
   tcpConnTest.test('close should', closeTest => {
     closeTest.test('call end method on socket', test => {
-      let socket = new EventEmitter()
+      const socket = new EventEmitter()
       socket.end = sandbox.stub()
 
-      let conn = TcpConnection.create(socket)
+      const conn = TcpConnection.create(socket)
       conn.close()
 
       test.ok(socket.end.calledOnce)
@@ -37,10 +37,10 @@ Test('TcpConnection', tcpConnTest => {
 
   tcpConnTest.test('pause should', pauseTest => {
     pauseTest.test('call pause method on socket', test => {
-      let socket = new EventEmitter()
+      const socket = new EventEmitter()
       socket.pause = sandbox.stub()
 
-      let conn = TcpConnection.create(socket)
+      const conn = TcpConnection.create(socket)
       conn.pause()
 
       test.ok(socket.pause.calledOnce)
@@ -52,10 +52,10 @@ Test('TcpConnection', tcpConnTest => {
 
   tcpConnTest.test('resume should', resumeTest => {
     resumeTest.test('call resume method on socket', test => {
-      let socket = new EventEmitter()
+      const socket = new EventEmitter()
       socket.resume = sandbox.stub()
 
-      let conn = TcpConnection.create(socket)
+      const conn = TcpConnection.create(socket)
       conn.resume()
 
       test.ok(socket.resume.calledOnce)
@@ -67,10 +67,10 @@ Test('TcpConnection', tcpConnTest => {
 
   tcpConnTest.test('receiving socket end should', receiveCloseTest => {
     receiveCloseTest.test('emit end event', test => {
-      let socket = new EventEmitter()
-      let endSpy = sandbox.spy()
+      const socket = new EventEmitter()
+      const endSpy = sandbox.spy()
 
-      let conn = TcpConnection.create(socket)
+      const conn = TcpConnection.create(socket)
       conn.on('end', endSpy)
 
       socket.emit('end')
@@ -84,12 +84,12 @@ Test('TcpConnection', tcpConnTest => {
 
   tcpConnTest.test('receving socket error should', receiveErrorTest => {
     receiveErrorTest.test('emit error event with existing error object', test => {
-      let socket = new EventEmitter()
-      let errorSpy = sandbox.spy()
+      const socket = new EventEmitter()
+      const errorSpy = sandbox.spy()
 
-      let socketErr = new Error('this is bad')
+      const socketErr = new Error('this is bad')
 
-      let conn = TcpConnection.create(socket)
+      const conn = TcpConnection.create(socket)
       conn.on('error', errorSpy)
 
       socket.emit('error', socketErr)
@@ -104,14 +104,14 @@ Test('TcpConnection', tcpConnTest => {
 
   tcpConnTest.test('receiving socket data should', receiveDataTest => {
     receiveDataTest.test('handle request and emit message event', test => {
-      let socket = new EventEmitter()
-      let messageSpy = sandbox.spy()
+      const socket = new EventEmitter()
+      const messageSpy = sandbox.spy()
 
-      let message = JSON.stringify({ id: 1, name: 'test' })
-      let sendBuffer = Fixtures.writeMessageToBufferWithLength(message)
-      let receiveBuffer = Fixtures.writeMessageToBuffer(message)
+      const message = JSON.stringify({ id: 1, name: 'test' })
+      const sendBuffer = Fixtures.writeMessageToBufferWithLength(message)
+      const receiveBuffer = Fixtures.writeMessageToBuffer(message)
 
-      let conn = TcpConnection.create(socket)
+      const conn = TcpConnection.create(socket)
       conn.on('message', messageSpy)
 
       socket.emit('data', sendBuffer)
@@ -122,23 +122,23 @@ Test('TcpConnection', tcpConnTest => {
     })
 
     receiveDataTest.test('handle multiple requests sent sequentially', test => {
-      let socket = new EventEmitter()
-      let messageSpy = sandbox.spy()
-      let receiveBuffers = []
+      const socket = new EventEmitter()
+      const messageSpy = sandbox.spy()
+      const receiveBuffers = []
 
-      let message = JSON.stringify({ id: 1, name: 'test' })
-      let sendBuffer = Fixtures.writeMessageToBufferWithLength(message)
+      const message = JSON.stringify({ id: 1, name: 'test' })
+      const sendBuffer = Fixtures.writeMessageToBufferWithLength(message)
       receiveBuffers.push(Fixtures.writeMessageToBuffer(message))
 
-      let message2 = JSON.stringify({ row: 5, key: 'key', value: 'val' })
-      let sendBuffer2 = Fixtures.writeMessageToBufferWithLength(message2)
+      const message2 = JSON.stringify({ row: 5, key: 'key', value: 'val' })
+      const sendBuffer2 = Fixtures.writeMessageToBufferWithLength(message2)
       receiveBuffers.push(Fixtures.writeMessageToBuffer(message2))
 
-      let message3 = JSON.stringify({ id: '1ab042bd-e098-4d96-ae8b-e07aefd04ca4', serviceName: 'service' })
-      let sendBuffer3 = Fixtures.writeMessageToBufferWithLength(message3)
+      const message3 = JSON.stringify({ id: '1ab042bd-e098-4d96-ae8b-e07aefd04ca4', serviceName: 'service' })
+      const sendBuffer3 = Fixtures.writeMessageToBufferWithLength(message3)
       receiveBuffers.push(Fixtures.writeMessageToBuffer(message3))
 
-      let conn = TcpConnection.create(socket)
+      const conn = TcpConnection.create(socket)
       conn.on('message', messageSpy)
 
       socket.emit('data', sendBuffer)
@@ -153,17 +153,17 @@ Test('TcpConnection', tcpConnTest => {
     })
 
     receiveDataTest.test('handle message split over multiple data events', test => {
-      let socket = new EventEmitter()
-      let messageSpy = sandbox.spy()
+      const socket = new EventEmitter()
+      const messageSpy = sandbox.spy()
 
-      let message = JSON.stringify({ id: '1ab042bd-e098-4d96-ae8b-e07aefd04ca4', serviceName: 'service' })
-      let sendBuffer = Fixtures.writeMessageToBufferWithLength(message)
-      let receiveBuffer = Fixtures.writeMessageToBuffer(message)
+      const message = JSON.stringify({ id: '1ab042bd-e098-4d96-ae8b-e07aefd04ca4', serviceName: 'service' })
+      const sendBuffer = Fixtures.writeMessageToBufferWithLength(message)
+      const receiveBuffer = Fixtures.writeMessageToBuffer(message)
 
-      let partialBuffer1 = sendBuffer.slice(0, 5)
-      let partialBuffer2 = sendBuffer.slice(5)
+      const partialBuffer1 = sendBuffer.slice(0, 5)
+      const partialBuffer2 = sendBuffer.slice(5)
 
-      let conn = TcpConnection.create(socket)
+      const conn = TcpConnection.create(socket)
       conn.on('message', messageSpy)
 
       socket.emit('data', partialBuffer1)
@@ -175,23 +175,23 @@ Test('TcpConnection', tcpConnTest => {
     })
 
     receiveDataTest.test('handle multiple messages split over multiple data events', test => {
-      let socket = new EventEmitter()
-      let messageSpy = sandbox.spy()
-      let receiveBuffers = []
+      const socket = new EventEmitter()
+      const messageSpy = sandbox.spy()
+      const receiveBuffers = []
 
-      let message = JSON.stringify({ id: '1ab042bd-e098-4d96-ae8b-e07aefd04ca4', serviceName: 'service' })
-      let sendBuffer = Fixtures.writeMessageToBufferWithLength(message)
+      const message = JSON.stringify({ id: '1ab042bd-e098-4d96-ae8b-e07aefd04ca4', serviceName: 'service' })
+      const sendBuffer = Fixtures.writeMessageToBufferWithLength(message)
       receiveBuffers.push(Fixtures.writeMessageToBuffer(message))
 
-      let message2 = JSON.stringify({ row: 5, key: 'key', value: 'val' })
-      let sendBuffer2 = Fixtures.writeMessageToBufferWithLength(message2)
+      const message2 = JSON.stringify({ row: 5, key: 'key', value: 'val' })
+      const sendBuffer2 = Fixtures.writeMessageToBufferWithLength(message2)
       receiveBuffers.push(Fixtures.writeMessageToBuffer(message2))
 
       // Append the beginning of the second buffer to the first buffer.
-      let partialBuffer1 = Fixtures.appendToBuffer(sendBuffer, sendBuffer2.slice(0, 5))
-      let partialBuffer2 = sendBuffer2.slice(5)
+      const partialBuffer1 = Fixtures.appendToBuffer(sendBuffer, sendBuffer2.slice(0, 5))
+      const partialBuffer2 = sendBuffer2.slice(5)
 
-      let conn = TcpConnection.create(socket)
+      const conn = TcpConnection.create(socket)
       conn.on('message', messageSpy)
 
       socket.emit('data', partialBuffer1)
@@ -205,21 +205,21 @@ Test('TcpConnection', tcpConnTest => {
     })
 
     receiveDataTest.test('handle multiple messages in one data event', test => {
-      let socket = new EventEmitter()
-      let messageSpy = sandbox.spy()
-      let receiveBuffers = []
+      const socket = new EventEmitter()
+      const messageSpy = sandbox.spy()
+      const receiveBuffers = []
 
-      let message = JSON.stringify({ id: '1ab042bd-e098-4d96-ae8b-e07aefd04ca4', serviceName: 'service' })
-      let sendBuffer = Fixtures.writeMessageToBufferWithLength(message)
+      const message = JSON.stringify({ id: '1ab042bd-e098-4d96-ae8b-e07aefd04ca4', serviceName: 'service' })
+      const sendBuffer = Fixtures.writeMessageToBufferWithLength(message)
       receiveBuffers.push(Fixtures.writeMessageToBuffer(message))
 
-      let message2 = JSON.stringify({ row: 5, key: 'key', value: 'val' })
-      let sendBuffer2 = Fixtures.writeMessageToBufferWithLength(message2)
+      const message2 = JSON.stringify({ row: 5, key: 'key', value: 'val' })
+      const sendBuffer2 = Fixtures.writeMessageToBufferWithLength(message2)
       receiveBuffers.push(Fixtures.writeMessageToBuffer(message2))
 
-      let combinedBuffer = Fixtures.appendToBuffer(sendBuffer, sendBuffer2)
+      const combinedBuffer = Fixtures.appendToBuffer(sendBuffer, sendBuffer2)
 
-      let conn = TcpConnection.create(socket)
+      const conn = TcpConnection.create(socket)
       conn.on('message', messageSpy)
 
       socket.emit('data', combinedBuffer)
@@ -232,12 +232,12 @@ Test('TcpConnection', tcpConnTest => {
     })
 
     receiveDataTest.test('not emit message event if sent data with no prefix header', test => {
-      let socket = new EventEmitter()
-      let messageSpy = sandbox.spy()
+      const socket = new EventEmitter()
+      const messageSpy = sandbox.spy()
 
-      let sendBuffer = Buffer.from('junk data')
+      const sendBuffer = Buffer.from('junk data')
 
-      let conn = TcpConnection.create(socket)
+      const conn = TcpConnection.create(socket)
       conn.on('message', messageSpy)
 
       socket.emit('data', sendBuffer)

--- a/test/unit/socket/index.test.js
+++ b/test/unit/socket/index.test.js
@@ -26,18 +26,18 @@ Test('SocketListener', socketListenerTest => {
 
   socketListenerTest.test('listen should', listenTest => {
     listenTest.test('call listen method on internal server and wait for listening event to resolve', test => {
-      let port = 1111
-      let hostname = 'localhost'
+      const port = 1111
+      const hostname = 'localhost'
 
-      let socket = new EventEmitter()
+      const socket = new EventEmitter()
       socket.listen = sandbox.stub()
 
       Net.createServer.returns(socket)
 
-      let socketListener = SocketListener.create()
+      const socketListener = SocketListener.create()
       test.notOk(socketListener._bound)
 
-      let listenPromise = socketListener.listen(port, hostname)
+      const listenPromise = socketListener.listen(port, hostname)
 
       socket.emit('listening')
 
@@ -55,23 +55,23 @@ Test('SocketListener', socketListenerTest => {
 
   socketListenerTest.test('close should', closeTest => {
     closeTest.test('call close method on internal socket, close open connections and emit close event', test => {
-      let socket = new EventEmitter()
+      const socket = new EventEmitter()
       socket.close = sandbox.stub()
       socket.close.callsArg(0)
 
       Net.createServer.returns(socket)
 
-      let conn = sandbox.stub()
+      const conn = sandbox.stub()
       conn.remoteAddress = 'localhost'
       conn.remotePort = 1111
 
-      let tcpConnection = new EventEmitter()
+      const tcpConnection = new EventEmitter()
       tcpConnection.close = sandbox.stub()
       TcpConnection.create.returns(tcpConnection)
 
-      let closeSpy = sandbox.spy()
+      const closeSpy = sandbox.spy()
 
-      let socketListener = SocketListener.create()
+      const socketListener = SocketListener.create()
       socketListener._bound = true
 
       socket.emit('connection', conn)
@@ -89,12 +89,12 @@ Test('SocketListener', socketListenerTest => {
     })
 
     closeTest.test('do nothing if internal server not bound', test => {
-      let socket = new EventEmitter()
+      const socket = new EventEmitter()
       socket.close = sandbox.stub()
 
       Net.createServer.returns(socket)
 
-      let socketListener = SocketListener.create()
+      const socketListener = SocketListener.create()
       socketListener._bound = false
 
       socketListener.close()
@@ -109,19 +109,19 @@ Test('SocketListener', socketListenerTest => {
 
   socketListenerTest.test('pause should', pauseTest => {
     pauseTest.test('set paused flag to true and pause any connections', test => {
-      let socket = new EventEmitter()
+      const socket = new EventEmitter()
 
       Net.createServer.returns(socket)
 
-      let conn = sandbox.stub()
+      const conn = sandbox.stub()
       conn.remoteAddress = 'localhost'
       conn.remotePort = 1111
 
-      let tcpConnection = new EventEmitter()
+      const tcpConnection = new EventEmitter()
       tcpConnection.pause = sandbox.stub()
       TcpConnection.create.returns(tcpConnection)
 
-      let socketListener = SocketListener.create()
+      const socketListener = SocketListener.create()
       test.notOk(socketListener._paused)
 
       socket.emit('connection', conn)
@@ -137,20 +137,20 @@ Test('SocketListener', socketListenerTest => {
 
   socketListenerTest.test('resume should', resumeTest => {
     resumeTest.test('set paused flag to false and resume any connections', test => {
-      let socket = new EventEmitter()
+      const socket = new EventEmitter()
 
       Net.createServer.returns(socket)
 
-      let conn = sandbox.stub()
+      const conn = sandbox.stub()
       conn.remoteAddress = 'localhost'
       conn.remotePort = 1111
 
-      let tcpConnection = new EventEmitter()
+      const tcpConnection = new EventEmitter()
       tcpConnection.pause = sandbox.stub()
       tcpConnection.resume = sandbox.stub()
       TcpConnection.create.returns(tcpConnection)
 
-      let socketListener = SocketListener.create()
+      const socketListener = SocketListener.create()
 
       socket.emit('connection', conn)
 
@@ -166,19 +166,19 @@ Test('SocketListener', socketListenerTest => {
     })
 
     resumeTest.test('do nothing if not paused', test => {
-      let socket = new EventEmitter()
+      const socket = new EventEmitter()
 
       Net.createServer.returns(socket)
 
-      let conn = sandbox.stub()
+      const conn = sandbox.stub()
       conn.remoteAddress = 'localhost'
       conn.remotePort = 1111
 
-      let tcpConnection = new EventEmitter()
+      const tcpConnection = new EventEmitter()
       tcpConnection.resume = sandbox.stub()
       TcpConnection.create.returns(tcpConnection)
 
-      let socketListener = SocketListener.create()
+      const socketListener = SocketListener.create()
 
       socket.emit('connection', conn)
 
@@ -196,15 +196,15 @@ Test('SocketListener', socketListenerTest => {
 
   socketListenerTest.test('receiving server close should', serverCloseTest => {
     serverCloseTest.test('call close method on internal server and emit close event', test => {
-      let socket = new EventEmitter()
+      const socket = new EventEmitter()
       socket.close = sandbox.stub()
       socket.close.callsArg(0)
 
       Net.createServer.returns(socket)
 
-      let closeSpy = sandbox.spy()
+      const closeSpy = sandbox.spy()
 
-      let socketListener = SocketListener.create()
+      const socketListener = SocketListener.create()
       socketListener._bound = true
       socketListener.on('close', closeSpy)
 
@@ -221,14 +221,14 @@ Test('SocketListener', socketListenerTest => {
 
   socketListenerTest.test('receiving server error should', serverErrorTest => {
     serverErrorTest.test('emit error event with existing error object', test => {
-      let socket = new EventEmitter()
+      const socket = new EventEmitter()
       Net.createServer.returns(socket)
 
-      let errorSpy = sandbox.spy()
+      const errorSpy = sandbox.spy()
 
-      let error = new Error('bad stuff in server')
+      const error = new Error('bad stuff in server')
 
-      let socketListener = SocketListener.create()
+      const socketListener = SocketListener.create()
       socketListener.on('error', errorSpy)
 
       socket.emit('error', error)
@@ -243,17 +243,17 @@ Test('SocketListener', socketListenerTest => {
 
   socketListenerTest.test('receiving server connection should', serverConnectionTest => {
     serverConnectionTest.test('create TcpConnection and add to list', test => {
-      let socket = new EventEmitter()
+      const socket = new EventEmitter()
       Net.createServer.returns(socket)
 
-      let conn = sandbox.stub()
+      const conn = sandbox.stub()
       conn.remoteAddress = 'localhost'
       conn.remotePort = 1111
 
-      let tcpConnection = new EventEmitter()
+      const tcpConnection = new EventEmitter()
       TcpConnection.create.returns(tcpConnection)
 
-      let socketListener = SocketListener.create()
+      const socketListener = SocketListener.create()
       test.equal(socketListener._connections.length, 0)
 
       socket.emit('connection', conn)
@@ -269,25 +269,25 @@ Test('SocketListener', socketListenerTest => {
 
   socketListenerTest.test('receiving TcpConnection message should', connMessageTest => {
     connMessageTest.test('convert message to utf8 string and emit message event', test => {
-      let socket = new EventEmitter()
+      const socket = new EventEmitter()
       Net.createServer.returns(socket)
 
-      let conn = sandbox.stub()
+      const conn = sandbox.stub()
       conn.remoteAddress = 'localhost'
       conn.remotePort = 1111
 
-      let tcpConnection = new EventEmitter()
+      const tcpConnection = new EventEmitter()
       TcpConnection.create.returns(tcpConnection)
 
-      let messageSpy = sandbox.spy()
+      const messageSpy = sandbox.spy()
 
-      let socketListener = SocketListener.create()
+      const socketListener = SocketListener.create()
       socketListener.on('message', messageSpy)
 
       socket.emit('connection', conn)
 
-      let message = JSON.stringify({ id: '1ab042bd-e098-4d96-ae8b-e07aefd04ca4', serviceName: 'service' })
-      let receiveBuffer = Fixtures.writeMessageToBuffer(message)
+      const message = JSON.stringify({ id: '1ab042bd-e098-4d96-ae8b-e07aefd04ca4', serviceName: 'service' })
+      const receiveBuffer = Fixtures.writeMessageToBuffer(message)
 
       tcpConnection.emit('message', receiveBuffer)
 
@@ -301,19 +301,19 @@ Test('SocketListener', socketListenerTest => {
 
   socketListenerTest.test('receiving TcpConnection end should', connCloseTest => {
     connCloseTest.test('remove connection from list and emit disconnect event', test => {
-      let socket = new EventEmitter()
+      const socket = new EventEmitter()
       Net.createServer.returns(socket)
 
-      let conn = sandbox.stub()
+      const conn = sandbox.stub()
       conn.remoteAddress = 'localhost'
       conn.remotePort = 1111
 
-      let tcpConnection = new EventEmitter()
+      const tcpConnection = new EventEmitter()
       TcpConnection.create.returns(tcpConnection)
 
-      let disconnectSpy = sandbox.spy()
+      const disconnectSpy = sandbox.spy()
 
-      let socketListener = SocketListener.create()
+      const socketListener = SocketListener.create()
       socketListener.on('disconnect', disconnectSpy)
 
       socket.emit('connection', conn)
@@ -332,19 +332,19 @@ Test('SocketListener', socketListenerTest => {
 
   socketListenerTest.test('receiving TcpConnection error should', connErrorTest => {
     connErrorTest.test('remove connection from list and emit disconnect event', test => {
-      let socket = new EventEmitter()
+      const socket = new EventEmitter()
       Net.createServer.returns(socket)
 
-      let conn = sandbox.stub()
+      const conn = sandbox.stub()
       conn.remoteAddress = 'localhost'
       conn.remotePort = 1111
 
-      let tcpConnection = new EventEmitter()
+      const tcpConnection = new EventEmitter()
       TcpConnection.create.returns(tcpConnection)
 
-      let disconnectSpy = sandbox.spy()
+      const disconnectSpy = sandbox.spy()
 
-      let socketListener = SocketListener.create()
+      const socketListener = SocketListener.create()
       socketListener.on('disconnect', disconnectSpy)
 
       socket.emit('connection', conn)


### PR DESCRIPTION
Part of: mojaloop/project#801

Adds 2 new steps to the ci process:
- `vunerability-check`: uses npm audit to check for and resolve vulnerabilities in packages
- `audit-license`: checks for disallowed or unknown licenses using the license-scanner tool

In addition:
- updated standard and ran `standard --fix` across the project
